### PR TITLE
refactor: rename vim-quake to vim-rogue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,24 +23,24 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact: vim-quake-x86_64-linux
+            artifact: vim-rogue-x86_64-linux
             strip: strip
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            artifact: vim-quake-aarch64-linux
+            artifact: vim-rogue-aarch64-linux
             strip: aarch64-linux-gnu-strip
           - target: x86_64-apple-darwin
             os: macos-latest
-            artifact: vim-quake-x86_64-macos
+            artifact: vim-rogue-x86_64-macos
           - target: aarch64-apple-darwin
             os: macos-latest
-            artifact: vim-quake-aarch64-macos
+            artifact: vim-rogue-aarch64-macos
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            artifact: vim-quake-x86_64-windows
+            artifact: vim-rogue-x86_64-windows
           - target: aarch64-pc-windows-msvc
             os: windows-latest
-            artifact: vim-quake-aarch64-windows
+            artifact: vim-rogue-aarch64-windows
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -67,20 +67,20 @@ jobs:
           docker run --rm -v "$PWD/target:/target:Z" \
             "ghcr.io/cross-rs/${{ matrix.target }}:main" \
             "${{ matrix.strip }}" \
-            "/target/${{ matrix.target }}/release/vim-quake"
+            "/target/${{ matrix.target }}/release/vim-rogue"
       - name: Strip binary (macOS)
         if: runner.os == 'macOS'
-        run: strip target/${{ matrix.target }}/release/vim-quake
+        run: strip target/${{ matrix.target }}/release/vim-rogue
 
       - name: Package (tar.gz)
         if: runner.os != 'Windows'
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf ../../../${{ matrix.artifact }}.tar.gz vim-quake
+          tar czf ../../../${{ matrix.artifact }}.tar.gz vim-rogue
       - name: Package (zip)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: Compress-Archive -Path "target/${{ matrix.target }}/release/vim-quake.exe" -DestinationPath "${{ matrix.artifact }}.zip"
+        run: Compress-Archive -Path "target/${{ matrix.target }}/release/vim-rogue.exe" -DestinationPath "${{ matrix.artifact }}.zip"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
 <!-- Generated: 2026-04-17 | Updated: 2026-04-22 -->
 <!-- Commit: f0954bc | Branch: feat/secret-cheat-codes -->
 
-# vim-quake
+# vim-rogue
 
 Terminal-based roguelike dungeon game (Rust + bracket-lib) teaching Vim motions through gameplay. 80×40 dungeon, 4 levels, 5 zone-gated areas, 13 Vim keybindings, FOV-aware enemy AI with patrol, fog-of-war visibility.
 
 ## Structure
 ```
-vim-quake/
+vim-rogue/
 ├── src/          # Application source code (see src/AGENTS.md)
 ├── tests/        # Integration tests — 393 tests across 9 files (see tests/AGENTS.md)
 ├── examples/     # Spike/prototype code (spike.rs)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 
 # vim-rogue
 
-Terminal-based roguelike dungeon game (Rust + bracket-lib) teaching Vim motions through gameplay. 80×40 dungeon, 4 levels, 5 zone-gated areas, 13 Vim keybindings, FOV-aware enemy AI with patrol, fog-of-war visibility.
+Roguelike dungeon game (Rust + bracket-lib). Teaches Vim motions through gameplay. 80×40 dungeon, 4 levels, 5 zones, 13 Vim keys, FOV-aware enemy AI + patrol, fog-of-war.
 
 ## Structure
 ```
@@ -36,37 +36,36 @@ lib.rs        → Re-exports all modules (9 lines)
 ## Where To Look
 | Task | Location | Notes |
 |------|----------|-------|
-| Add a new Vim motion | `src/player.rs` + `src/types.rs` (VimMotion enum) | Also update game.rs parse_motion |
-| Change dungeon layout | `src/map.rs` (carve_level, build_level_2/3/4) | grid[y][x] row-major; 4 levels |
-| Add UI elements | `src/renderer.rs` | Pure display — never mutates state |
-| Change game flow | `src/game.rs` (handle_key, tick, execute_motion) | Two-phase input for f/t/dd/gg; pause menu on ESC/q |
+| Add new Vim motion | `src/player.rs` + `src/types.rs` (VimMotion enum) | Update `game.rs` parse_motion too |
+| Change dungeon layout | `src/map.rs` (carve_level, build_level_2/3/4) | `grid[y][x]` row-major; 4 levels |
+| Add UI elements | `src/renderer.rs` | Display only — never mutates state |
+| Change game flow | `src/game.rs` (handle_key, tick, execute_motion) | Two-phase input for f/t/dd/gg; ESC/q = pause |
 | Change pause menu | `src/game.rs` + `src/renderer.rs` + `src/types.rs` | GameState::Paused, PauseOption, render_pause_overlay |
-| Add new types | `src/types.rs` | All modules import via `crate::types::*` |
+| Add new types | `src/types.rs` | All modules use `crate::types::*` |
 | Change enemy AI | `src/enemy.rs` (step_toward_player, has_line_of_sight, patrol_step) | FOV-gated BFS chase + patrol, called from game.rs enemies_step |
-| Change FOV/visibility | `src/visibility.rs` (compute_fov) | VisibilityMap with Hidden/Explored/Visible states |
-| Add animations | `src/animation.rs` | AnimationState + Interpolator; clock via GameClock trait |
-| Add sound effects | `src/audio.rs` (SoundEffect enum + AudioManager) | Audio disabled by default |
-| Fix a bug | Check tests in `tests/` directory (393 integration tests across 9 files) | main.rs and lib.rs have no tests |
+| Change FOV/visibility | `src/visibility.rs` (compute_fov) | Hidden/Explored/Visible states |
+| Add animations | `src/animation.rs` | AnimationState + Interpolator; GameClock trait |
+| Add sound effects | `src/audio.rs` (SoundEffect enum + AudioManager) | Disabled by default |
+| Fix bug | `tests/` (393 integration tests, 9 files) | main.rs + lib.rs have no tests |
 
 ## Conventions
-- Rust edition 2024. Formatting configured via `rustfmt.toml` (`use_small_heuristics = "Max"`, `edition = "2024"`).
-- Integration tests in `tests/` directory (393 tests across 9 files). Shared helpers in `tests/common/mod.rs`.
-- Test helpers: `test_map()`, `started_app_with_map()`, `test_app()`, `assert_approx_eq()`, `approx_eq()`, `tick_timer()`, `tick_state()`.
-- `renderer.rs` internals are `pub` for integration test access (e.g., `screen_meets_minimum_size`, `phase_definitions`, `exit_glow`, etc.).
-- `lib.rs` re-exports all modules. `main.rs` is thin (~32 lines).
-- `is_passable` = `Tile::Floor`, `Tile::Exit`, or `Tile::Torchlight`. `Tile::Obstacle` is not passable but can be destroyed by `dd`.
-- w/b motions scan horizontally along clear paths, stopping at non-passable tiles (walls/obstacles).
-- G/gg motions scan vertically from current position, stopping at non-passable tiles (walls/obstacles).
-- `renderer.rs` is read-only — never mutates App state.
+- Rust edition 2024. `rustfmt.toml`: `use_small_heuristics = "Max"`, `edition = "2024"`.
+- 393 integration tests in `tests/` (9 files). Shared helpers in `tests/common/mod.rs`.
+- Helpers: `test_map()`, `started_app_with_map()`, `test_app()`, `assert_approx_eq()`, `approx_eq()`, `tick_timer()`, `tick_state()`.
+- `renderer.rs` internals `pub` for test access (e.g. `screen_meets_minimum_size`, `phase_definitions`, `exit_glow`).
+- `lib.rs` re-exports all. `main.rs` thin (~32 lines).
+- `is_passable` = `Tile::Floor`, `Tile::Exit`, `Tile::Torchlight`. `Tile::Obstacle` not passable but `dd` destroys it.
+- w/b: horizontal scan, stop at non-passable. G/gg: vertical scan, stop at non-passable.
+- `renderer.rs` read-only — never mutates App.
 - `Player::handle_motion` takes `&mut Map` (dd deletes obstacles).
-- `GameClock` trait for time — `RealClock` in production, `TestClock` in tests.
-- Animation durations: player 150ms (`PLAYER_MOVE_MS`), enemy 200ms (`ENEMY_MOVE_MS`).
-- FOV radius: `FOV_RADIUS` constant in types.rs. Enemy FOV: `ENEMY_FOV_RADIUS = 8`.
-- Enemies have FOV-aware AI: chase via BFS when player visible (`has_line_of_sight`), patrol within `PatrolArea` otherwise.
-- Level 4 enemies have room-based patrol areas; no-torchlight rooms have ≥2 enemies.
-- Audio disabled by default; `AudioManager::enable()` to activate.
-- Error handling: `BError` from bracket-lib in main.rs. `anyhow` listed in Cargo.toml but unused in source.
-- `unwrap()`/`expect()` present in non-test source code.
+- `GameClock` trait: `RealClock` prod, `TestClock` tests.
+- Animations: player 150ms (`PLAYER_MOVE_MS`), enemy 200ms (`ENEMY_MOVE_MS`).
+- FOV: `FOV_RADIUS` in types.rs. Enemy FOV: `ENEMY_FOV_RADIUS = 8`.
+- Enemy AI: BFS chase when player visible (`has_line_of_sight`), patrol in `PatrolArea` otherwise.
+- Level 4: room-based patrol; no-torchlight rooms have ≥2 enemies.
+- Audio off by default; `AudioManager::enable()` to turn on.
+- Errors: `BError` from bracket-lib in main.rs. `anyhow` in Cargo.toml but unused.
+- `unwrap()`/`expect()` in non-test source.
 
 ## Commands
 ```bash
@@ -79,27 +78,27 @@ cargo run              # Launch game in terminal
 ```
 
 ## Verification Checklist
-After any code change, run ALL of these before considering work complete:
-1. `cargo fmt --check` — ensure formatting is clean
+After any code change, run all:
+1. `cargo fmt --check` — formatting clean
 2. `cargo clippy` — zero warnings
-3. `cargo test` — all 393 tests pass
-4. Update `CHANGELOG.md` — add entry under `[Unreleased]` or new version section
+3. `cargo test` — all 393 pass
+4. Update `CHANGELOG.md` — add entry under `[Unreleased]` or new version
 
 ## Dependencies
 | Crate | Version | Used In |
 |-------|---------|---------|
-| anyhow | 1.0 | Listed but unused in source |
-| bracket-lib | 0.8.7 | main.rs (terminal + rendering), renderer.rs, audio.rs |
+| anyhow | 1.0 | Listed but unused |
+| bracket-lib | 0.8.7 | main.rs, renderer.rs, audio.rs |
 
 ## Notes
-- CI/CD: GitHub Actions for lint, test, build, and cross-platform release (`.github/workflows/`).
+- CI: GitHub Actions (`.github/workflows/`). Lint, test, build, cross-platform release.
 - No Makefile, build.rs, or custom scripts.
-- Config files: `rustfmt.toml` (formatting rules). No clippy.toml or .editorconfig.
-- Coordinate system: `grid[y][x]` — always bounds-check before access.
-- 4 dungeon levels: Level 1 (basic), Level 2 (inverted maze + obstacles), Level 3 (zigzag + BFS enemies), Level 4 (fortress rooms + FOV-aware patrol enemies).
-- Lives system: 3 lives; enemy collision costs a life; 0 lives → Lost state → retry current level.
-- HP system: Level 4 enemies have HP (`hp: Some(30)`); melee attack (x key) deals 10 damage; 3 hits to kill.
-- Torchlight checkpoints: step on torchlight to activate permanent FOV radius 6; death with checkpoint → respawn (HP restore + teleport).
-- `examples/spike.rs`: bracket-lib proof-of-concept spike.
+- Config: `rustfmt.toml` only. No clippy.toml or .editorconfig.
+- Coords: `grid[y][x]` — bounds-check before access.
+- Levels: 1 (basic), 2 (inverted maze + obstacles), 3 (zigzag + BFS enemies), 4 (fortress rooms + FOV patrol).
+- Lives: 3. Enemy collision = -1 life. 0 lives → Lost → retry level.
+- HP: Level 4 enemies have `hp: Some(30)`. Melee (x key) = 10 dmg. 3 hits kill.
+- Torchlight checkpoints: activate permanent FOV radius 6. Death with checkpoint → respawn (HP + teleport).
+- `examples/spike.rs`: bracket-lib PoC spike.
 
 <!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/AGENTS.original.md
+++ b/AGENTS.original.md
@@ -1,0 +1,105 @@
+<!-- Generated: 2026-04-17 | Updated: 2026-04-22 -->
+<!-- Commit: f0954bc | Branch: feat/secret-cheat-codes -->
+
+# vim-rogue
+
+Terminal-based roguelike dungeon game (Rust + bracket-lib) teaching Vim motions through gameplay. 80×40 dungeon, 4 levels, 5 zone-gated areas, 13 Vim keybindings, FOV-aware enemy AI with patrol, fog-of-war visibility.
+
+## Structure
+```
+vim-rogue/
+├── src/          # Application source code (see src/AGENTS.md)
+├── tests/        # Integration tests — 393 tests across 9 files (see tests/AGENTS.md)
+├── examples/     # Spike/prototype code (spike.rs)
+├── resources/    # CP437 font sprite sheets (PNG) for bracket-lib rendering
+├── Cargo.toml    # Edition 2024, deps: anyhow (unused), bracket-lib
+├── Cargo.lock
+├── README.md
+└── .gitignore    # target/, *.rs.bk, *.pdb, mutants.out*/, .omc/
+```
+
+## Architecture
+```
+main.rs       → bracket-lib setup + event loop (44 lines)
+game.rs       → App state, event handling, motion dispatch, FOV-gated enemy turns, win/loss, trail, audio (814 lines)
+player.rs     → Player + 13 motion implementations (247 lines)
+map.rs        → 80×40 grid, 5 zones, 4 dungeon levels, corridor carving, enemy spawns + patrol areas (471 lines)
+renderer.rs   → bracket-lib rendering: title, viewport, sidebar, minimap, win/loss screens, ASCII art (899 lines)
+types.rs      → Position, Tile, Zone, VimMotion, Direction, Enemy, PatrolArea, App, RenderGrid, ViewModel (355 lines)
+animation.rs  → GameClock, AnimationState, AnimationTimer, Interpolator (easing) (182 lines)
+visibility.rs → VisibilityMap with FOV (explored/visible/hidden states) (124 lines)
+enemy.rs      → Enemy struct with FOV-aware BFS chase + room patrol (180 lines)
+audio.rs      → AudioManager with SoundEffect enum, graceful fallback (55 lines)
+lib.rs        → Re-exports all modules (9 lines)
+```
+
+## Where To Look
+| Task | Location | Notes |
+|------|----------|-------|
+| Add a new Vim motion | `src/player.rs` + `src/types.rs` (VimMotion enum) | Also update game.rs parse_motion |
+| Change dungeon layout | `src/map.rs` (carve_level, build_level_2/3/4) | grid[y][x] row-major; 4 levels |
+| Add UI elements | `src/renderer.rs` | Pure display — never mutates state |
+| Change game flow | `src/game.rs` (handle_key, tick, execute_motion) | Two-phase input for f/t/dd/gg; pause menu on ESC/q |
+| Change pause menu | `src/game.rs` + `src/renderer.rs` + `src/types.rs` | GameState::Paused, PauseOption, render_pause_overlay |
+| Add new types | `src/types.rs` | All modules import via `crate::types::*` |
+| Change enemy AI | `src/enemy.rs` (step_toward_player, has_line_of_sight, patrol_step) | FOV-gated BFS chase + patrol, called from game.rs enemies_step |
+| Change FOV/visibility | `src/visibility.rs` (compute_fov) | VisibilityMap with Hidden/Explored/Visible states |
+| Add animations | `src/animation.rs` | AnimationState + Interpolator; clock via GameClock trait |
+| Add sound effects | `src/audio.rs` (SoundEffect enum + AudioManager) | Audio disabled by default |
+| Fix a bug | Check tests in `tests/` directory (393 integration tests across 9 files) | main.rs and lib.rs have no tests |
+
+## Conventions
+- Rust edition 2024. Formatting configured via `rustfmt.toml` (`use_small_heuristics = "Max"`, `edition = "2024"`).
+- Integration tests in `tests/` directory (393 tests across 9 files). Shared helpers in `tests/common/mod.rs`.
+- Test helpers: `test_map()`, `started_app_with_map()`, `test_app()`, `assert_approx_eq()`, `approx_eq()`, `tick_timer()`, `tick_state()`.
+- `renderer.rs` internals are `pub` for integration test access (e.g., `screen_meets_minimum_size`, `phase_definitions`, `exit_glow`, etc.).
+- `lib.rs` re-exports all modules. `main.rs` is thin (~32 lines).
+- `is_passable` = `Tile::Floor`, `Tile::Exit`, or `Tile::Torchlight`. `Tile::Obstacle` is not passable but can be destroyed by `dd`.
+- w/b motions scan horizontally along clear paths, stopping at non-passable tiles (walls/obstacles).
+- G/gg motions scan vertically from current position, stopping at non-passable tiles (walls/obstacles).
+- `renderer.rs` is read-only — never mutates App state.
+- `Player::handle_motion` takes `&mut Map` (dd deletes obstacles).
+- `GameClock` trait for time — `RealClock` in production, `TestClock` in tests.
+- Animation durations: player 150ms (`PLAYER_MOVE_MS`), enemy 200ms (`ENEMY_MOVE_MS`).
+- FOV radius: `FOV_RADIUS` constant in types.rs. Enemy FOV: `ENEMY_FOV_RADIUS = 8`.
+- Enemies have FOV-aware AI: chase via BFS when player visible (`has_line_of_sight`), patrol within `PatrolArea` otherwise.
+- Level 4 enemies have room-based patrol areas; no-torchlight rooms have ≥2 enemies.
+- Audio disabled by default; `AudioManager::enable()` to activate.
+- Error handling: `BError` from bracket-lib in main.rs. `anyhow` listed in Cargo.toml but unused in source.
+- `unwrap()`/`expect()` present in non-test source code.
+
+## Commands
+```bash
+cargo fmt              # Format code (uses rustfmt.toml)
+cargo fmt --check      # Check formatting without writing
+cargo clippy           # Lint
+cargo test             # Run 393 integration tests
+cargo build            # Compile
+cargo run              # Launch game in terminal
+```
+
+## Verification Checklist
+After any code change, run ALL of these before considering work complete:
+1. `cargo fmt --check` — ensure formatting is clean
+2. `cargo clippy` — zero warnings
+3. `cargo test` — all 393 tests pass
+4. Update `CHANGELOG.md` — add entry under `[Unreleased]` or new version section
+
+## Dependencies
+| Crate | Version | Used In |
+|-------|---------|---------|
+| anyhow | 1.0 | Listed but unused in source |
+| bracket-lib | 0.8.7 | main.rs (terminal + rendering), renderer.rs, audio.rs |
+
+## Notes
+- CI/CD: GitHub Actions for lint, test, build, and cross-platform release (`.github/workflows/`).
+- No Makefile, build.rs, or custom scripts.
+- Config files: `rustfmt.toml` (formatting rules). No clippy.toml or .editorconfig.
+- Coordinate system: `grid[y][x]` — always bounds-check before access.
+- 4 dungeon levels: Level 1 (basic), Level 2 (inverted maze + obstacles), Level 3 (zigzag + BFS enemies), Level 4 (fortress rooms + FOV-aware patrol enemies).
+- Lives system: 3 lives; enemy collision costs a life; 0 lives → Lost state → retry current level.
+- HP system: Level 4 enemies have HP (`hp: Some(30)`); melee attack (x key) deals 10 damage; 3 hits to kill.
+- Torchlight checkpoints: step on torchlight to activate permanent FOV radius 6; death with checkpoint → respawn (HP restore + teleport).
+- `examples/spike.rs`: bracket-lib proof-of-concept spike.
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Renamed project from `vim-quake` to `vim-rogue`
 - Replaced `String`-based cheat buffer with fixed-size `[Option<char>; 2]` struct (`CheatBuffer`) for O(1) push operations (no `remove(0)` shifting)
 - Guarded all cheat-related fields, enums, functions, and tests behind `#[cfg(debug_assertions)]` — compiled out of production builds entirely
 - Added `can_pass_to()` helper on `Player` and `is_invincible()` helper on `App` for clean conditional access to debug-only behavior
@@ -86,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Zilk 16x16 and Kjammer font support
 - CI pipeline for lint, test, build, and cross-platform release
 
-[0.2.2]: https://github.com/tuandzung/vim-quake-game/compare/v0.2.1...v0.2.2
-[0.2.1]: https://github.com/tuandzung/vim-quake-game/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/tuandzung/vim-quake-game/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/tuandzung/vim-quake-game/releases/tag/v0.1.0
+[0.2.2]: https://github.com/tuandzung/vim-rogue-game/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/tuandzung/vim-rogue-game/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/tuandzung/vim-rogue-game/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/tuandzung/vim-rogue-game/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,7 +1717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "vim-quake"
+name = "vim-rogue"
 version = "0.2.2"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vim-quake"
+name = "vim-rogue"
 version = "0.2.2"
 edition = "2024"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vim-quake
+# vim-rogue
 
 A roguelike dungeon game with ASCII aesthetic in a graphical window, teaching Vim motions through gameplay. Navigate four 80×40 dungeon levels using real Vim keybindings, dodge enemies, and reach the exit. Built with [bracket-lib](https://github.com/amethyst/bracket-lib) for roguelike-specific rendering, FOV, and tile-based graphics.
 

--- a/examples/spike.rs
+++ b/examples/spike.rs
@@ -18,7 +18,7 @@ impl GameState for State {
 
 fn main() -> BError {
     let context = BTermBuilder::simple80x50()
-        .with_title("vim-quake spike")
+        .with_title("vim-rogue spike")
         .with_vsync(false)
         .with_fps_cap(30.0)
         .build()?;
@@ -65,7 +65,7 @@ mod tests {
     #[ignore = "opens a native window; run locally to smoke-test builder context creation"]
     fn builder_smoke_creates_an_80_by_50_context() {
         let _context = BTermBuilder::simple80x50()
-            .with_title("vim-quake spike")
+            .with_title("vim-rogue spike")
             .with_vsync(false)
             .with_fps_cap(30.0)
             .build()

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -2,7 +2,7 @@
 <!-- Generated: 2026-04-17 | Updated: 2026-04-22 -->
 # src
 
-All application source code for vim-quake. Tests are in the `tests/` directory (integration tests).
+All application source code for vim-rogue. Tests are in the `tests/` directory (integration tests).
 
 ## Key Files
 | File | Lines | Role |

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -2,33 +2,33 @@
 <!-- Generated: 2026-04-17 | Updated: 2026-04-22 -->
 # src
 
-All application source code for vim-rogue. Tests are in the `tests/` directory (integration tests).
+All vim-rogue source. Tests in `tests/` (integration only).
 
 ## Key Files
 | File | Lines | Role |
 |------|-------|------|
-| `main.rs` | 44 | Binary entry — bracket-lib setup, event loop, quit handling via `ctx.quit()`, delegates to game/renderer |
-| `lib.rs` | 9 | Library root — `pub mod` re-exports all modules |
-| `game.rs` | 814 | `App` state, `handle_key`/`tick`, `parse_motion`, `execute_motion`, `spawn_enemies_for_current_level`, `enemies_step`, win/loss/retry, pause menu, trail, audio dispatch |
-| `player.rs` | 247 | `Player` struct + 13 motion impls (h/j/k/l/w/b/0/$/G/gg/f/t/dd) |
-| `map.rs` | 471 | `Map` struct, 80×40 grid, 5 zones, 4 levels (`carve_level`, `build_level_2/3/4`), enemy spawn points + patrol areas |
-| `renderer.rs` | 899 | bracket-lib rendering — title/gameplay/win/lost/pause screens, viewport, sidebar, minimap, zone colors |
+| `main.rs` | 44 | Binary entry — bracket-lib setup, event loop, `ctx.quit()`, delegates to game/renderer |
+| `lib.rs` | 9 | Library root — `pub mod` re-exports |
+| `game.rs` | 814 | `App` state, `handle_key`/`tick`, `parse_motion`, `execute_motion`, `spawn_enemies_for_current_level`, `enemies_step`, win/loss/retry, pause, trail, audio dispatch |
+| `player.rs` | 247 | `Player` + 13 motion impls (h/j/k/l/w/b/0/$/G/gg/f/t/dd) |
+| `map.rs` | 471 | `Map`, 80×40 grid, 5 zones, 4 levels (`carve_level`, `build_level_2/3/4`), enemy spawns + patrol areas |
+| `renderer.rs` | 899 | bracket-lib render — title/gameplay/win/lost/pause screens, viewport, sidebar, minimap, zone colors |
 | `types.rs` | 355 | Position, Tile, Zone, VimMotion, Direction, Enemy, PatrolArea, GameState, PauseOption, App, RenderGrid, ViewModel, ScreenModel |
 | `animation.rs` | 182 | `GameClock` trait, `RealClock`/`TestClock`, `AnimationState`, `AnimationTimer`, `Interpolator` |
-| `visibility.rs` | 124 | `VisibilityMap` with `compute_fov`, `VisibilityState` (Hidden/Explored/Visible) |
-| `enemy.rs` | 180 | `Enemy` struct with FOV-aware BFS `step_toward_player`, `has_line_of_sight`, `patrol_step` |
-| `audio.rs` | 55 | `AudioManager` + `SoundEffect` enum, graceful no-op fallback |
+| `visibility.rs` | 124 | `VisibilityMap` + `compute_fov`, `VisibilityState` (Hidden/Explored/Visible) |
+| `enemy.rs` | 180 | `Enemy` + FOV-aware BFS `step_toward_player`, `has_line_of_sight`, `patrol_step` |
+| `audio.rs` | 55 | `AudioManager` + `SoundEffect` enum, no-op fallback |
 
 ## Where To Look
 | Task | File | What to change |
 |------|------|----------------|
-| Add Vim motion | `player.rs` + `types.rs` | VimMotion enum, handle_motion match arm, game.rs parse_motion |
+| Add Vim motion | `player.rs` + `types.rs` | VimMotion enum, handle_motion arm, game.rs parse_motion |
 | Change dungeon | `map.rs` | carve_level, build_level_2/3/4, assign_zones |
-| Change UI | `renderer.rs` | Pure display only — never mutates state |
-| Change game flow | `game.rs` | handle_key, tick, pending_input two-phase for f/t/dd/gg; ESC/q opens pause menu |
-| Change pause menu | `game.rs` + `renderer.rs` + `types.rs` | GameState::Paused, PauseOption enum, render_pause_overlay |
-| Add shared type | `types.rs` | All modules import via `crate::types::*` |
-| Change enemy AI | `enemy.rs` | step_toward_player (BFS), has_line_of_sight (Bresenham LOS), patrol_step (room patrol), called via game.rs enemies_step |
+| Change UI | `renderer.rs` | Display only — never mutates state |
+| Change game flow | `game.rs` | handle_key, tick, pending_input for f/t/dd/gg; ESC/q opens pause |
+| Change pause menu | `game.rs` + `renderer.rs` + `types.rs` | GameState::Paused, PauseOption, render_pause_overlay |
+| Add shared type | `types.rs` | All modules `use crate::types::*` |
+| Change enemy AI | `enemy.rs` | step_toward_player (BFS), has_line_of_sight (Bresenham), patrol_step, called via game.rs enemies_step |
 | Change visibility | `visibility.rs` | compute_fov, VisibilityMap, demote_visible_to_explored |
 | Add animation | `animation.rs` | AnimationState + Interpolator; durations as constants |
 | Add sound | `audio.rs` | SoundEffect enum + AudioManager.play() |
@@ -48,44 +48,44 @@ lib.rs        ← main.rs (implicit)
 ```
 
 ## Conventions
-- Formatting configured via `rustfmt.toml` (`use_small_heuristics = "Max"`, `edition = "2024"`). Run `cargo fmt --check` before committing.
-- `grid[y][x]` row-major indexing — always bounds-check before access.
-- Event handling: single-key motions execute immediately; f/t/dd/gg set `pending_input` for next keypress.
-- Pause menu: ESC or q opens pause overlay; j/k or ↑/↓ navigate options; Enter selects; ESC resumes. `tick()` freezes when paused.
-- `Tile` has `glyph()` for char + `Display` for string. `VimMotion` has `key_label()`, `display_name()`, `description()`.
-- Input queue: `input_queue` in App buffers keypresses during animation; dequeued after animation completes.
-- `GameClock` trait: `RealClock` in production, `TestClock` (deterministic) in tests.
-- Animation durations: `PLAYER_MOVE_MS` (150ms), `ENEMY_MOVE_MS` (200ms), `EFFECT_MS` in animation.rs.
-- FOV: `compute_fov` uses ray-casting with `FOV_RADIUS`; `demote_visible_to_explored` called before each recomputation.
-- Enemy AI: FOV-aware with `ENEMY_FOV_RADIUS=8`. `has_line_of_sight` uses Bresenham LOS. Enemies chase via BFS when player visible, patrol within `PatrolArea` when not. `patrol_area` field on Enemy, `enemy_patrol_areas` on Map. Melee combat gated on `hp.is_some()` (not level number).
-- Audio: disabled by default; `play()` no-ops when disabled; `SoundEffect` enum in audio.rs.
+- `rustfmt.toml`: `use_small_heuristics = "Max"`, `edition = "2024"`. Run `cargo fmt --check` pre-commit.
+- `grid[y][x]` row-major — always bounds-check.
+- Single-key motions fire immediately; f/t/dd/gg set `pending_input` for next key.
+- Pause: ESC/q opens overlay; j/k or ↑/↓ navigate; Enter selects; ESC resumes. `tick()` freezes when paused.
+- `Tile`: `glyph()` (char) + `Display` (string). `VimMotion`: `key_label()`, `display_name()`, `description()`.
+- `input_queue` in App buffers keys during animation; dequeued after complete.
+- `GameClock`: `RealClock` prod, `TestClock` (deterministic) tests.
+- Durations: `PLAYER_MOVE_MS` (150ms), `ENEMY_MOVE_MS` (200ms), `EFFECT_MS` in animation.rs.
+- FOV: `compute_fov` ray-casts with `FOV_RADIUS`; `demote_visible_to_explored` before each recomputation.
+- Enemy AI: FOV-aware, `ENEMY_FOV_RADIUS=8`. Bresenham LOS. BFS chase when visible, `PatrolArea` patrol when not. `patrol_area` on Enemy, `enemy_patrol_areas` on Map. Melee gated on `hp.is_some()`.
+- Audio: disabled default; `play()` no-ops when off.
 
 ## Tests
-393 integration tests in `tests/` directory (no inline tests in src/):
+393 integration tests in `tests/` (no inline tests in src/):
 | File | Tests | Coverage |
 |------|-------|----------|
-| `tests/game.rs` | 140 | Motions, pending input, animations, input queue, level transitions, enemies, audio, trail, visibility, win/loss/retry, pause menu, melee combat |
+| `tests/game.rs` | 140 | Motions, pending input, animations, input queue, level transitions, enemies, audio, trail, visibility, win/loss/retry, pause, melee |
 | `tests/renderer.rs` | 53 | Zone colors, wall glyphs, duration formatting, phases, exit glow, trail colors, minimap, fog, centering |
-| `tests/map.rs` | 46 | Dimensions, tiles, passability, zones, corridors, obstacles, 4 levels, reachability, enemy spawns, patrol areas, torchlight rooms |
-| `tests/animation.rs` | 34 | Timer progress, interpolation, easing, AnimationState, TestClock determinism |
+| `tests/map.rs` | 46 | Dimensions, tiles, passability, zones, corridors, obstacles, 4 levels, reachability, spawns, patrol, torchlight |
+| `tests/animation.rs` | 34 | Timer progress, interpolation, easing, AnimationState, TestClock |
 | `tests/visibility.rs` | 29 | FOV center, wall blocking, radius, explored persistence, reset, corridors, symmetry, edge cases |
-| `tests/player.rs` | 29 | All 13 motions + boundaries + wall-stopping (w/b/G/gg) + motion recording |
+| `tests/player.rs` | 29 | All 13 motions + boundaries + wall-stopping (w/b/G/gg) + recording |
 | `tests/enemy.rs` | 21 | BFS movement, diagonal, walls, adjacency, corridors, shortest path, LOS, patrol |
 | `tests/types.rs` | 25 | Tile glyphs, motion labels/names/descriptions, zone titles, direction deltas, RenderGrid, ViewModel, Enemy |
-| `tests/audio.rs` | 16 | Manager lifecycle, play no-op, enable/disable, rapid play, sound variants |
+| `tests/audio.rs` | 16 | Lifecycle, play no-op, enable/disable, rapid play, variants |
 | `main.rs` | 0 | No tests (thin wrapper) |
-| `lib.rs` | 0 | No tests (re-exports only) |
+| `lib.rs` | 0 | No tests (re-exports) |
 
-Shared test helpers in `tests/common/mod.rs`: `test_map(w,h)`, `started_app_with_map(map,pos)`, `test_app()`, `assert_approx_eq()`, `approx_eq()`, `tick_timer()`, `tick_state()`, `all_transparent()`, `with_walls()`, `with_transparent_tiles()`.
+Shared helpers in `tests/common/mod.rs`: `test_map(w,h)`, `started_app_with_map(map,pos)`, `test_app()`, `assert_approx_eq()`, `approx_eq()`, `tick_timer()`, `tick_state()`, `all_transparent()`, `with_walls()`, `with_transparent_tiles()`.
 
 ## Notes
-- Map defaults: start (2,2), exit (76,36). Zones: 16 columns each.
-- Zone 5 has obstacles (only area with `Tile::Obstacle`).
+- Map: start (2,2), exit (76,36). Zones: 16 cols each.
+- Zone 5 = obstacles only (`Tile::Obstacle`).
 - Level 2: inverted maze, obstacles in earlier zones, different start/exit.
-- Level 3: zigzag corridors, enemy spawn points from `map.enemy_spawns`, torchlights at corridor junctions.
-- Level 4: fortress rooms, 9 enemies with room-based patrol areas, no-torchlight rooms have ≥2 enemies, HP-based combat.
-- `Enemy` glyph: `⚡` (default). Stored in `Enemy` struct field.
-- `RenderGrid`/`RenderCell`/`ViewModel`/`ScreenModel` are renderer-specific types in types.rs.
-- `examples/spike.rs`: bracket-lib proof-of-concept, not part of main build.
+- Level 3: zigzag corridors, spawns from `map.enemy_spawns`, torchlights at junctions.
+- Level 4: fortress rooms, 9 enemies + room patrol, no-torchlight rooms have ≥2 enemies, HP combat.
+- Enemy glyph: `⚡` (default), stored in struct field.
+- `RenderGrid`/`RenderCell`/`ViewModel`/`ScreenModel` = renderer types in types.rs.
+- `examples/spike.rs`: bracket-lib POC, not in main build.
 
 <!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/src/AGENTS.original.md
+++ b/src/AGENTS.original.md
@@ -1,0 +1,91 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-04-17 | Updated: 2026-04-22 -->
+# src
+
+All application source code for vim-rogue. Tests are in the `tests/` directory (integration tests).
+
+## Key Files
+| File | Lines | Role |
+|------|-------|------|
+| `main.rs` | 44 | Binary entry — bracket-lib setup, event loop, quit handling via `ctx.quit()`, delegates to game/renderer |
+| `lib.rs` | 9 | Library root — `pub mod` re-exports all modules |
+| `game.rs` | 814 | `App` state, `handle_key`/`tick`, `parse_motion`, `execute_motion`, `spawn_enemies_for_current_level`, `enemies_step`, win/loss/retry, pause menu, trail, audio dispatch |
+| `player.rs` | 247 | `Player` struct + 13 motion impls (h/j/k/l/w/b/0/$/G/gg/f/t/dd) |
+| `map.rs` | 471 | `Map` struct, 80×40 grid, 5 zones, 4 levels (`carve_level`, `build_level_2/3/4`), enemy spawn points + patrol areas |
+| `renderer.rs` | 899 | bracket-lib rendering — title/gameplay/win/lost/pause screens, viewport, sidebar, minimap, zone colors |
+| `types.rs` | 355 | Position, Tile, Zone, VimMotion, Direction, Enemy, PatrolArea, GameState, PauseOption, App, RenderGrid, ViewModel, ScreenModel |
+| `animation.rs` | 182 | `GameClock` trait, `RealClock`/`TestClock`, `AnimationState`, `AnimationTimer`, `Interpolator` |
+| `visibility.rs` | 124 | `VisibilityMap` with `compute_fov`, `VisibilityState` (Hidden/Explored/Visible) |
+| `enemy.rs` | 180 | `Enemy` struct with FOV-aware BFS `step_toward_player`, `has_line_of_sight`, `patrol_step` |
+| `audio.rs` | 55 | `AudioManager` + `SoundEffect` enum, graceful no-op fallback |
+
+## Where To Look
+| Task | File | What to change |
+|------|------|----------------|
+| Add Vim motion | `player.rs` + `types.rs` | VimMotion enum, handle_motion match arm, game.rs parse_motion |
+| Change dungeon | `map.rs` | carve_level, build_level_2/3/4, assign_zones |
+| Change UI | `renderer.rs` | Pure display only — never mutates state |
+| Change game flow | `game.rs` | handle_key, tick, pending_input two-phase for f/t/dd/gg; ESC/q opens pause menu |
+| Change pause menu | `game.rs` + `renderer.rs` + `types.rs` | GameState::Paused, PauseOption enum, render_pause_overlay |
+| Add shared type | `types.rs` | All modules import via `crate::types::*` |
+| Change enemy AI | `enemy.rs` | step_toward_player (BFS), has_line_of_sight (Bresenham LOS), patrol_step (room patrol), called via game.rs enemies_step |
+| Change visibility | `visibility.rs` | compute_fov, VisibilityMap, demote_visible_to_explored |
+| Add animation | `animation.rs` | AnimationState + Interpolator; durations as constants |
+| Add sound | `audio.rs` | SoundEffect enum + AudioManager.play() |
+
+## Internal Dependencies
+```
+types.rs      ← (all modules)
+map.rs        ← player.rs, enemy.rs, game.rs
+player.rs     ← game.rs
+enemy.rs      ← game.rs
+visibility.rs ← game.rs, renderer.rs
+animation.rs  ← game.rs
+audio.rs      ← game.rs
+renderer.rs   ← main.rs (reads types for display)
+game.rs       ← main.rs
+lib.rs        ← main.rs (implicit)
+```
+
+## Conventions
+- Formatting configured via `rustfmt.toml` (`use_small_heuristics = "Max"`, `edition = "2024"`). Run `cargo fmt --check` before committing.
+- `grid[y][x]` row-major indexing — always bounds-check before access.
+- Event handling: single-key motions execute immediately; f/t/dd/gg set `pending_input` for next keypress.
+- Pause menu: ESC or q opens pause overlay; j/k or ↑/↓ navigate options; Enter selects; ESC resumes. `tick()` freezes when paused.
+- `Tile` has `glyph()` for char + `Display` for string. `VimMotion` has `key_label()`, `display_name()`, `description()`.
+- Input queue: `input_queue` in App buffers keypresses during animation; dequeued after animation completes.
+- `GameClock` trait: `RealClock` in production, `TestClock` (deterministic) in tests.
+- Animation durations: `PLAYER_MOVE_MS` (150ms), `ENEMY_MOVE_MS` (200ms), `EFFECT_MS` in animation.rs.
+- FOV: `compute_fov` uses ray-casting with `FOV_RADIUS`; `demote_visible_to_explored` called before each recomputation.
+- Enemy AI: FOV-aware with `ENEMY_FOV_RADIUS=8`. `has_line_of_sight` uses Bresenham LOS. Enemies chase via BFS when player visible, patrol within `PatrolArea` when not. `patrol_area` field on Enemy, `enemy_patrol_areas` on Map. Melee combat gated on `hp.is_some()` (not level number).
+- Audio: disabled by default; `play()` no-ops when disabled; `SoundEffect` enum in audio.rs.
+
+## Tests
+393 integration tests in `tests/` directory (no inline tests in src/):
+| File | Tests | Coverage |
+|------|-------|----------|
+| `tests/game.rs` | 140 | Motions, pending input, animations, input queue, level transitions, enemies, audio, trail, visibility, win/loss/retry, pause menu, melee combat |
+| `tests/renderer.rs` | 53 | Zone colors, wall glyphs, duration formatting, phases, exit glow, trail colors, minimap, fog, centering |
+| `tests/map.rs` | 46 | Dimensions, tiles, passability, zones, corridors, obstacles, 4 levels, reachability, enemy spawns, patrol areas, torchlight rooms |
+| `tests/animation.rs` | 34 | Timer progress, interpolation, easing, AnimationState, TestClock determinism |
+| `tests/visibility.rs` | 29 | FOV center, wall blocking, radius, explored persistence, reset, corridors, symmetry, edge cases |
+| `tests/player.rs` | 29 | All 13 motions + boundaries + wall-stopping (w/b/G/gg) + motion recording |
+| `tests/enemy.rs` | 21 | BFS movement, diagonal, walls, adjacency, corridors, shortest path, LOS, patrol |
+| `tests/types.rs` | 25 | Tile glyphs, motion labels/names/descriptions, zone titles, direction deltas, RenderGrid, ViewModel, Enemy |
+| `tests/audio.rs` | 16 | Manager lifecycle, play no-op, enable/disable, rapid play, sound variants |
+| `main.rs` | 0 | No tests (thin wrapper) |
+| `lib.rs` | 0 | No tests (re-exports only) |
+
+Shared test helpers in `tests/common/mod.rs`: `test_map(w,h)`, `started_app_with_map(map,pos)`, `test_app()`, `assert_approx_eq()`, `approx_eq()`, `tick_timer()`, `tick_state()`, `all_transparent()`, `with_walls()`, `with_transparent_tiles()`.
+
+## Notes
+- Map defaults: start (2,2), exit (76,36). Zones: 16 columns each.
+- Zone 5 has obstacles (only area with `Tile::Obstacle`).
+- Level 2: inverted maze, obstacles in earlier zones, different start/exit.
+- Level 3: zigzag corridors, enemy spawn points from `map.enemy_spawns`, torchlights at corridor junctions.
+- Level 4: fortress rooms, 9 enemies with room-based patrol areas, no-torchlight rooms have ≥2 enemies, HP-based combat.
+- `Enemy` glyph: `⚡` (default). Stored in `Enemy` struct field.
+- `RenderGrid`/`RenderCell`/`ViewModel`/`ScreenModel` are renderer-specific types in types.rs.
+- `examples/spike.rs`: bracket-lib proof-of-concept, not part of main build.
+
+<!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use bracket_lib::prelude::*;
 
-use vim_quake::game;
-use vim_quake::renderer;
-use vim_quake::types::App;
+use vim_rogue::game;
+use vim_rogue::renderer;
+use vim_rogue::types::App;
 
 embedded_resource!(UNICODE_FONT, "../resources/Kjammer_16x16.png");
 
@@ -18,7 +18,7 @@ impl GameState for AppWrapper {
             game::handle_key(&mut self.app, key, ctx.shift);
         }
 
-        if self.app.game_state == vim_quake::types::GameState::Quit {
+        if self.app.game_state == vim_rogue::types::GameState::Quit {
             ctx.quit();
             return;
         }
@@ -38,7 +38,7 @@ fn main() -> BError {
         .with_font("Kjammer_16x16.png", 16, 16)
         .with_simple_console(80u32, 50u32, "Kjammer_16x16.png")
         .with_tile_dimensions(16u32, 16u32)
-        .with_title("vim-quake")
+        .with_title("vim-rogue")
         .build()?;
     main_loop(context, AppWrapper { app: App::new() })
 }

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -40,7 +40,7 @@
 - Each test file mirrors a src/ module (e.g., `tests/player.rs` ↔ `src/player.rs`).
 - `handle_key(app, VirtualKeyCode, shift: bool)` is the main input entry point for game tests.
 - `tick(&mut app, delta_ms: f64)` advances the game clock and processes one frame.
-- Animation constants: `PLAYER_MOVE_MS = 150.0`, `ENEMY_MOVE_MS = 200.0`, `ATTACK_EFFECT_MS = 200.0` — import from `vim_quake::animation`.
+- Animation constants: `PLAYER_MOVE_MS = 150.0`, `ENEMY_MOVE_MS = 200.0`, `ATTACK_EFFECT_MS = 200.0` — import from `vim_rogue::animation`.
 - `TestClock` provides deterministic timing; always use it in tests (never `RealClock`).
 - Enemy construction: `Enemy::new(pos)` for default; override fields with `Enemy { position: pos, hp: Some(30), ..Enemy::new(pos) }` for Level 4 enemies.
 - Level 4 helper: `level4_app_with_enemy(pos, hp)` in `tests/game.rs` creates app on Level 4 map with one enemy at given position.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -2,7 +2,7 @@
 
 # tests
 
-393 integration tests across 9 files. No inline tests in src/. Shared helpers in `tests/common/mod.rs`.
+393 integration tests, 9 files. No inline tests in src/. Shared helpers in `tests/common/mod.rs`.
 
 ## Test Files
 | File | Tests | Lines | Coverage |
@@ -20,34 +20,34 @@
 ## Shared Helpers (`common/mod.rs`)
 | Helper | Signature | Purpose |
 |--------|-----------|---------|
-| `test_map(w, h)` | `-> Map` | Blank map with all-Floor grid |
-| `started_app_with_map(map, pos)` | `-> App` | App at given position on given map, GameState::Playing |
+| `test_map(w, h)` | `-> Map` | Blank map, all-Floor grid |
+| `started_app_with_map(map, pos)` | `-> App` | App at pos on map, GameState::Playing |
 | `test_app()` | `-> App` | App on default Level 1 map |
 | `tick_timer(timer, clock, delta_ms)` | | Advance timer with TestClock |
 | `tick_state(state, clock, delta_ms)` | | Advance AnimationState with TestClock |
-| `tick(app, delta_ms)` | | Convenience: advance App clock + call `tick()` |
+| `tick(app, delta_ms)` | | Advance App clock + call `tick()` |
 
 ## Where To Look
 | Task | File | Notes |
 |------|------|-------|
-| Test a motion | `player.rs` | Use `test_app()` + `handle_key()` |
-| Test enemy behavior | `enemy.rs` | Manual enemy construction + `step_toward_player` |
+| Test motion | `player.rs` | `test_app()` + `handle_key()` |
+| Test enemy | `enemy.rs` | Manual enemy + `step_toward_player` |
 | Test level layout | `map.rs` | `Map::level(N)` + grid assertions |
-| Test game state transitions | `game.rs` | `handle_key()`, `tick()`, state assertions |
-| Test visibility | `visibility.rs` | `VisibilityMap` + `compute_fov` + `with_walls()` helper |
+| Test state transitions | `game.rs` | `handle_key()`, `tick()`, state assertions |
+| Test visibility | `visibility.rs` | `VisibilityMap` + `compute_fov` + `with_walls()` |
 
 ## Conventions
-- Each test file mirrors a src/ module (e.g., `tests/player.rs` ↔ `src/player.rs`).
-- `handle_key(app, VirtualKeyCode, shift: bool)` is the main input entry point for game tests.
-- `tick(&mut app, delta_ms: f64)` advances the game clock and processes one frame.
+- Test file mirrors src/ module (`tests/player.rs` ↔ `src/player.rs`).
+- `handle_key(app, VirtualKeyCode, shift: bool)` = main input entry for game tests.
+- `tick(&mut app, delta_ms: f64)` advances clock, processes one frame.
 - Animation constants: `PLAYER_MOVE_MS = 150.0`, `ENEMY_MOVE_MS = 200.0`, `ATTACK_EFFECT_MS = 200.0` — import from `vim_rogue::animation`.
-- `TestClock` provides deterministic timing; always use it in tests (never `RealClock`).
-- Enemy construction: `Enemy::new(pos)` for default; override fields with `Enemy { position: pos, hp: Some(30), ..Enemy::new(pos) }` for Level 4 enemies.
-- Level 4 helper: `level4_app_with_enemy(pos, hp)` in `tests/game.rs` creates app on Level 4 map with one enemy at given position.
-- `renderer.rs` internals are `pub` for test access (e.g., `screen_meets_minimum_size`, `phase_definitions`, `exit_glow`).
+- `TestClock` = deterministic timing. Always use in tests, never `RealClock`.
+- Enemy: `Enemy::new(pos)` default; override with `Enemy { position: pos, hp: Some(30), ..Enemy::new(pos) }` for Level 4.
+- Level 4 helper: `level4_app_with_enemy(pos, hp)` in `tests/game.rs` — app on Level 4 map, one enemy at pos.
+- `renderer.rs` internals `pub` for test access (`screen_meets_minimum_size`, `phase_definitions`, `exit_glow`).
 
 ## Notes
-- Formatting configured via `rustfmt.toml` — run `cargo fmt --check` before committing.
-- `tests/common/mod.rs` has some helpers trigger `dead_code` warnings — expected, only used by subset of test files.
-- Game test file (`tests/game.rs`) is largest at 1968 lines due to comprehensive state machine coverage.
+- `rustfmt.toml` config. Run `cargo fmt --check` before commit.
+- `tests/common/mod.rs` helpers trigger `dead_code` warnings — expected, used by subset of test files.
+- `tests/game.rs` largest at 1968 lines — comprehensive state machine coverage.
 - No `#[should_panic]` tests — error cases return gracefully.

--- a/tests/AGENTS.original.md
+++ b/tests/AGENTS.original.md
@@ -1,0 +1,53 @@
+<!-- Parent: ../AGENTS.md -->
+
+# tests
+
+393 integration tests across 9 files. No inline tests in src/. Shared helpers in `tests/common/mod.rs`.
+
+## Test Files
+| File | Tests | Lines | Coverage |
+|------|-------|-------|----------|
+| `game.rs` | 140 | 1968 | Motions, pending input, animations, input queue, level transitions, enemies, audio, trail, visibility, win/loss/retry, pause menu, melee combat, checkpoint respawn |
+| `map.rs` | 46 | 539 | Dimensions, tiles, passability, zones, corridors, obstacles, 4 levels, reachability, enemy spawns, patrol areas, torchlight room presence |
+| `renderer.rs` | 53 | 428 | Zone colors, wall glyphs, duration formatting, phases, exit glow, trail colors, minimap, fog, centering |
+| `visibility.rs` | 29 | 420 | FOV center, wall blocking, radius, explored persistence, reset, corridors, symmetry, edge cases, multi-source FOV |
+| `player.rs` | 29 | 324 | All 13 motions + boundaries + wall-stopping (w/b/G/gg) + motion recording |
+| `animation.rs` | 34 | 349 | Timer progress, interpolation, easing, AnimationState, TestClock determinism, attack effects |
+| `types.rs` | 25 | 216 | Tile glyphs, motion labels/names/descriptions, zone titles, direction deltas, RenderGrid, ViewModel, Enemy |
+| `enemy.rs` | 21 | 265 | BFS movement, diagonal, walls, adjacency, corridors, shortest path, LOS, patrol |
+| `audio.rs` | 16 | 191 | Manager lifecycle, play no-op, enable/disable, rapid play, sound variants |
+
+## Shared Helpers (`common/mod.rs`)
+| Helper | Signature | Purpose |
+|--------|-----------|---------|
+| `test_map(w, h)` | `-> Map` | Blank map with all-Floor grid |
+| `started_app_with_map(map, pos)` | `-> App` | App at given position on given map, GameState::Playing |
+| `test_app()` | `-> App` | App on default Level 1 map |
+| `tick_timer(timer, clock, delta_ms)` | | Advance timer with TestClock |
+| `tick_state(state, clock, delta_ms)` | | Advance AnimationState with TestClock |
+| `tick(app, delta_ms)` | | Convenience: advance App clock + call `tick()` |
+
+## Where To Look
+| Task | File | Notes |
+|------|------|-------|
+| Test a motion | `player.rs` | Use `test_app()` + `handle_key()` |
+| Test enemy behavior | `enemy.rs` | Manual enemy construction + `step_toward_player` |
+| Test level layout | `map.rs` | `Map::level(N)` + grid assertions |
+| Test game state transitions | `game.rs` | `handle_key()`, `tick()`, state assertions |
+| Test visibility | `visibility.rs` | `VisibilityMap` + `compute_fov` + `with_walls()` helper |
+
+## Conventions
+- Each test file mirrors a src/ module (e.g., `tests/player.rs` ↔ `src/player.rs`).
+- `handle_key(app, VirtualKeyCode, shift: bool)` is the main input entry point for game tests.
+- `tick(&mut app, delta_ms: f64)` advances the game clock and processes one frame.
+- Animation constants: `PLAYER_MOVE_MS = 150.0`, `ENEMY_MOVE_MS = 200.0`, `ATTACK_EFFECT_MS = 200.0` — import from `vim_rogue::animation`.
+- `TestClock` provides deterministic timing; always use it in tests (never `RealClock`).
+- Enemy construction: `Enemy::new(pos)` for default; override fields with `Enemy { position: pos, hp: Some(30), ..Enemy::new(pos) }` for Level 4 enemies.
+- Level 4 helper: `level4_app_with_enemy(pos, hp)` in `tests/game.rs` creates app on Level 4 map with one enemy at given position.
+- `renderer.rs` internals are `pub` for test access (e.g., `screen_meets_minimum_size`, `phase_definitions`, `exit_glow`).
+
+## Notes
+- Formatting configured via `rustfmt.toml` — run `cargo fmt --check` before committing.
+- `tests/common/mod.rs` has some helpers trigger `dead_code` warnings — expected, only used by subset of test files.
+- Game test file (`tests/game.rs`) is largest at 1968 lines due to comprehensive state machine coverage.
+- No `#[should_panic]` tests — error cases return gracefully.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/tests/animation.rs
+++ b/tests/animation.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::{assert_approx_eq, tick_state, tick_timer};
-use vim_quake::animation::*;
+use vim_rogue::animation::*;
 
 #[test]
 fn timer_at_zero_is_zero_progress() {

--- a/tests/audio.rs
+++ b/tests/audio.rs
@@ -1,5 +1,5 @@
 use std::time::Instant;
-use vim_quake::audio::*;
+use vim_rogue::audio::*;
 
 #[test]
 fn audio_manager_new_is_created() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,14 +1,14 @@
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
-use vim_quake::animation::{AnimationState, AnimationTimer, GameClock, TestClock};
-use vim_quake::audio::AudioManager;
-use vim_quake::map::Map;
-use vim_quake::player::Player;
-use vim_quake::types::*;
-use vim_quake::visibility::VisibilityMap;
+use vim_rogue::animation::{AnimationState, AnimationTimer, GameClock, TestClock};
+use vim_rogue::audio::AudioManager;
+use vim_rogue::map::Map;
+use vim_rogue::player::Player;
+use vim_rogue::types::*;
+use vim_rogue::visibility::VisibilityMap;
 
 #[cfg(debug_assertions)]
-use vim_quake::types::CheatBuffer;
+use vim_rogue::types::CheatBuffer;
 
 pub fn test_map(width: usize, height: usize) -> Map {
     Map {

--- a/tests/enemy.rs
+++ b/tests/enemy.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::test_map;
-use vim_quake::types::{Enemy, PatrolArea, Position, Tile, Zone};
+use vim_rogue::types::{Enemy, PatrolArea, Position, Tile, Zone};
 
 #[test]
 fn enemy_new_has_default_glyph() {

--- a/tests/game.rs
+++ b/tests/game.rs
@@ -4,16 +4,16 @@ use bracket_lib::prelude::VirtualKeyCode;
 use common::{started_app_with_map, test_map};
 use std::time::Duration;
 use std::time::Instant;
-use vim_quake::animation::{
+use vim_rogue::animation::{
     ATTACK_EFFECT_MS, AttackEffect, AttackEffectKind, ENEMY_MOVE_MS, PLAYER_MOVE_MS,
 };
-use vim_quake::game::{handle_key, tick};
-use vim_quake::map::Map;
-use vim_quake::types::{
+use vim_rogue::game::{handle_key, tick};
+use vim_rogue::map::Map;
+use vim_rogue::types::{
     App, Direction, Enemy, GameState, MAX_HP, PatrolArea, PauseOption, PendingInput, Position,
     TOTAL_LEVELS, Tile, VimMotion, Zone,
 };
-use vim_quake::visibility::{VisibilityMap, VisibilityState};
+use vim_rogue::visibility::{VisibilityMap, VisibilityState};
 
 #[test]
 fn app_new_starts_playing() {
@@ -379,12 +379,12 @@ fn no_animation_on_failed_move() {
 fn app_trail_caps_at_max() {
     let mut app = started_app_with_map(test_map(20, 1), Position { x: 1, y: 0 });
 
-    for _ in 0..(vim_quake::types::TRAIL_MAX + 2) {
+    for _ in 0..(vim_rogue::types::TRAIL_MAX + 2) {
         handle_key(&mut app, VirtualKeyCode::L, false);
         handle_key(&mut app, VirtualKeyCode::H, false);
     }
 
-    assert!(app.trail.len() <= vim_quake::types::TRAIL_MAX);
+    assert!(app.trail.len() <= vim_rogue::types::TRAIL_MAX);
 }
 
 #[test]
@@ -1465,7 +1465,7 @@ fn level_4_colliding_enemy_persists_on_checkpoint_respawn() {
     }];
 
     // Move right — enemy steps toward player, collision occurs, HP -> 0 -> checkpoint respawn
-    vim_quake::game::handle_key(&mut app, VirtualKeyCode::L, false);
+    vim_rogue::game::handle_key(&mut app, VirtualKeyCode::L, false);
 
     assert_eq!(app.game_state, GameState::Dying);
     tick(&mut app, ATTACK_EFFECT_MS);
@@ -1531,7 +1531,7 @@ fn advance_level_clears_attack_effects() {
     let mut map = test_map(10, 1);
     map.set_tile(4, 0, Tile::Exit);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.attack_effects.push(vim_quake::animation::AttackEffect::new(
+    app.attack_effects.push(vim_rogue::animation::AttackEffect::new(
         AttackEffectKind::PlayerStrike,
         3,
         0,

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -1,5 +1,5 @@
-use vim_quake::map::Map;
-use vim_quake::types::{Position, Tile, Zone};
+use vim_rogue::map::Map;
+use vim_rogue::types::{Position, Tile, Zone};
 
 #[test]
 fn map_new_creates_80x40_grid() {

--- a/tests/player.rs
+++ b/tests/player.rs
@@ -1,9 +1,9 @@
 mod common;
 
 use common::test_map;
-use vim_quake::map::Map;
-use vim_quake::player::Player;
-use vim_quake::types::{Position, Tile, VimMotion, Zone};
+use vim_rogue::map::Map;
+use vim_rogue::player::Player;
+use vim_rogue::types::{Position, Tile, VimMotion, Zone};
 
 #[test]
 fn player_new_has_starting_position() {

--- a/tests/renderer.rs
+++ b/tests/renderer.rs
@@ -5,12 +5,12 @@ use common::{approx_eq, test_app};
 use std::collections::VecDeque;
 use std::time::Duration;
 use std::time::Instant;
-use vim_quake::animation::{AnimationState, AttackEffectKind, ENEMY_MOVE_MS};
-use vim_quake::map::Map;
-use vim_quake::player::Player;
-use vim_quake::renderer::*;
-use vim_quake::types::{App, Enemy, GameState, MAX_HP, Position, Tile, VimMotion, Zone};
-use vim_quake::visibility::{VisibilityMap, VisibilityState};
+use vim_rogue::animation::{AnimationState, AttackEffectKind, ENEMY_MOVE_MS};
+use vim_rogue::map::Map;
+use vim_rogue::player::Player;
+use vim_rogue::renderer::*;
+use vim_rogue::types::{App, Enemy, GameState, MAX_HP, Position, Tile, VimMotion, Zone};
+use vim_rogue::visibility::{VisibilityMap, VisibilityState};
 
 #[test]
 fn zone_wall_colors() {

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -1,4 +1,4 @@
-use vim_quake::types::*;
+use vim_rogue::types::*;
 
 #[test]
 fn tile_glyph_wall() {

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -1,8 +1,8 @@
 mod common;
 
 use common::{all_transparent, with_transparent_tiles, with_walls};
-use vim_quake::types::Position;
-use vim_quake::visibility::{VisibilityMap, VisibilityState};
+use vim_rogue::types::Position;
+use vim_rogue::visibility::{VisibilityMap, VisibilityState};
 
 #[test]
 fn new_map_all_hidden() {


### PR DESCRIPTION
## Summary
- Rename project from `vim-quake` to `vim-rogue` — it's a roguelike, not a Quake game
- Updates package name, crate lib (`vim_rogue`), binary, window titles, CI artifacts, and all documentation

## Test plan
- [x] `cargo build` compiles as `vim-rogue`
- [x] All 393 tests pass
- [x] `cargo fmt --check` clean
- [x] No remaining `vim-quake` references in source

## Summary by Sourcery

Rename the project and crate from vim-quake to vim-rogue across code, tests, CI, and docs.

Enhancements:
- Rename the Rust package, crate, binary, and module path from vim-quake to vim-rogue for consistency with the game concept.

CI:
- Update release workflow artifact names, binary paths, and packaging commands to use vim-rogue instead of vim-quake.

Documentation:
- Update README, AGENTS docs, changelog entry, and GitHub release/changelog links to reflect the new vim-rogue project name.

Tests:
- Update all integration tests to import from the vim_rogue crate and adjust references and guidance accordingly.