### PR TITLE
refactor: split App god object into domain aggregates

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,48 @@
+# vim-rogue Domain Context
+
+## Aggregates
+
+The game state is organized into domain aggregates, each owning a cohesive slice of state and behavior. `App` is a thin coordinator — it sequences cross-aggregate flows but owns no logic itself.
+
+### World
+The dungeon environment: terrain, visibility, enemies, and torchlight state. All spatial queries go through World. Enemy AI (BFS chase, patrol) runs inside World. FOV computation is World's responsibility — it knows the map and who can see what.
+
+- Owns: map, visibility, enemies, activated torchlights
+- Key invariant: visibility is always consistent with current map state
+- Reset: `new_for_level(n)` replaces terrain, enemies, visibility for a dungeon level
+
+### PlayerState
+The player's identity and progression: position, health, trail of visited positions, discovered Vim motions, current level, checkpoint, and pending respawn. PlayerState knows *why* the player needs to respawn, not just where.
+
+- Owns: position, hp, trail, motion tracking, level, checkpoint, pending_respawn
+- Key invariant: hp <= MAX_HP, trail length <= TRAIL_MAX
+- Produces status messages for actions it owns (motion feedback, damage, respawn)
+
+### InputState
+Input buffering for multi-key Vim commands. Tracks pending two-phase input (f/t/dd/gg) and queued keys during animation.
+
+- Owns: input_queue, pending_input
+- Key invariant: pending_input is consumed before input_queue is processed
+
+### Session
+The meta-layer: game lifecycle state, timing, pause menu selection, and the current status message. Session knows *whether* the game is playing, not *what* the player is doing.
+
+- Owns: game_state, pause_selection, started, status_message, timing
+- Key invariant: timing only advances when game_state is Playing
+
+### App (Coordinator)
+Sequences cross-aggregate flows: level transitions, enemy collision → damage → death/respawn, pause/resume. No business logic — calls aggregate methods in the right order.
+
+## Domain Rules
+
+- Levels: 4 dungeon levels, each with distinct layout. Level exit → advance_level. Death → retry_level (same layout). 0 hp → game over.
+- FOV: player has FOV_RADIUS=10. Torchlight checkpoints grant permanent TORCHLIGHT_FOV_RADIUS=6. Enemy FOV radius is 8.
+- Combat: enemy collision = -1 life (or -HP on level 4). Level 4 enemies have HP and can be meleed (3 hits kill).
+- Checkpoints: torchlight activation saves position. Death with checkpoint → respawn there instead of level start.
+- Motions: 13 Vim keys. Single-key motions fire immediately; f/t/dd/gg use two-phase input via InputState.
+
+## Naming
+
+- "World" not "MapContainer" or "GameState" — it's the dungeon as environment
+- "PlayerState" not "Player" — the inner `Player` struct handles motion, PlayerState wraps it with progression
+- "Session" not "UIState" — timing and lifecycle aren't UI concerns

--- a/docs/specs/aggregate-refactor.md
+++ b/docs/specs/aggregate-refactor.md
@@ -1,0 +1,403 @@
+# Spec: Split App into Domain Aggregates
+
+4 incremental steps. Each step passes all 393 tests before proceeding.
+
+## Step 1: Create Aggregate Structs, Move Fields
+
+Mechanical field migration. No behavior changes. All `pub` fields remain `pub`.
+
+### types.rs — new structs
+
+```rust
+pub struct World {
+    pub map: Map,
+    pub visibility: VisibilityMap,
+    pub enemies: Vec<Enemy>,
+    pub activated_torchlights: HashSet<Position>,
+}
+
+pub struct PlayerState {
+    pub inner: Player,
+    pub hp: i32,
+    pub trail: VecDeque<Position>,
+    pub motion_count: usize,
+    pub discovered_motions: HashSet<VimMotion>,
+    pub level: usize,
+    pub last_checkpoint: Option<Position>,
+    pub pending_respawn: Option<Position>,
+}
+
+pub struct InputState {
+    pub input_queue: Vec<(VirtualKeyCode, bool)>,
+    pub pending_input: Option<PendingInput>,
+}
+
+pub struct Session {
+    pub game_state: GameState,
+    pub pause_selection: PauseOption,
+    pub started: bool,
+    pub status_message: String,
+    pub start_time: Instant,
+    pub elapsed: Duration,
+    pub final_time: Option<Duration>,
+}
+```
+
+### types.rs — new App
+
+```rust
+pub struct App {
+    pub world: World,
+    pub player: PlayerState,
+    pub input: InputState,
+    pub session: Session,
+    // Animation stays flat (candidate 2 extracts these)
+    pub player_animation: Option<AnimationState>,
+    pub enemy_animations: Vec<(usize, AnimationState)>,
+    pub attack_effects: Vec<AttackEffect>,
+    pub audio: AudioManager,
+    #[cfg(debug_assertions)]
+    pub cheat_buf: CheatBuffer,
+    #[cfg(debug_assertions)]
+    pub cheat_god_mode: bool,
+}
+```
+
+9 fields (down from 29). Animation (3 fields) + audio + debug (2) = remaining flat fields.
+
+### Constructor methods
+
+Each aggregate gets a `new(...)` that sets sensible defaults:
+
+- `World::new_for_level(level: usize) -> Self` — builds Map::level(n), VisibilityMap::new, spawns enemies, empty torchlights
+- `PlayerState::new(position: Position) -> Self` — Player::new(pos), MAX_HP, empty trail, level 1
+- `InputState::new() -> Self` — empty queue, no pending
+- `Session::new() -> Self` — Playing, Resume, started=false, zero timing
+
+`App::new()` becomes:
+```rust
+pub fn new() -> Self {
+    let world = World::new_for_level(1);
+    let start = world.map.start;
+    Self {
+        world,
+        player: PlayerState::new(start),
+        input: InputState::new(),
+        session: Session::new(),
+        player_animation: None,
+        enemy_animations: Vec::new(),
+        attack_effects: Vec::new(),
+        audio: AudioManager::new(),
+        #[cfg(debug_assertions)]
+        cheat_buf: CheatBuffer::new(),
+        #[cfg(debug_assertions)]
+        cheat_god_mode: false,
+    }
+}
+```
+
+### Accessor migration (find-replace across codebase)
+
+Every file that touches App fields changes:
+
+| Before | After |
+|--------|-------|
+| `app.map` | `app.world.map` |
+| `app.visibility` | `app.world.visibility` |
+| `app.enemies` | `app.world.enemies` |
+| `app.activated_torchlights` | `app.world.activated_torchlights` |
+| `app.player.position` | `app.player.inner.position` |
+| `app.player.handle_motion(...)` | `app.player.inner.handle_motion(...)` |
+| `app.hp` | `app.player.hp` |
+| `app.trail` | `app.player.trail` |
+| `app.motion_count` | `app.player.motion_count` |
+| `app.discovered_motions` | `app.player.discovered_motions` |
+| `app.level` | `app.player.level` |
+| `app.last_checkpoint` | `app.player.last_checkpoint` |
+| `app.pending_respawn` | `app.player.pending_respawn` |
+| `app.input_queue` | `app.input.input_queue` |
+| `app.pending_input` | `app.input.pending_input` |
+| `app.game_state` | `app.session.game_state` |
+| `app.pause_selection` | `app.session.pause_selection` |
+| `app.started` | `app.session.started` |
+| `app.status_message` | `app.session.status_message` |
+| `app.start_time` | `app.session.start_time` |
+| `app.elapsed` | `app.session.elapsed` |
+| `app.final_time` | `app.session.final_time` |
+
+### Files changed
+
+- `src/types.rs` — new structs + modified App
+- `src/game.rs` — all accessor changes (largest diff)
+- `src/renderer.rs` — all accessor changes
+- `src/main.rs` — App::new() call (if it constructs App)
+- `tests/common/mod.rs` — test_app(), started_app_with_map()
+- `tests/game.rs` — accessor changes
+- `tests/renderer.rs` — accessor changes
+- `tests/map.rs` — minor (tests Map directly, not App)
+
+### Helper methods to add to App for common compound accessors
+
+These reduce churn in step 2+:
+
+```rust
+impl App {
+    // Convenience: current map start position
+    pub fn map_start(&self) -> Position { self.world.map.start }
+
+    // Convenience: update visibility for current player position
+    pub fn update_visibility(&mut self) {
+        let pos = self.player.inner.position;
+        let torchlights = &self.world.activated_torchlights;
+        self.world.visibility.demote_visible_to_explored();
+        self.world.visibility.compute_fov(pos, FOV_RADIUS, |p| {
+            self.world.map.get_tile(p.x, p.y).is_transparent()
+        });
+        for tp in torchlights {
+            if self.world.visibility.is_visible(*tp) {
+                self.world.visibility.compute_fov(*tp, TORCHLIGHT_FOV_RADIUS, |p| {
+                    self.world.map.get_tile(p.x, p.y).is_transparent()
+                });
+            }
+        }
+    }
+}
+```
+
+### Verification
+
+- `cargo fmt --check` clean
+- `cargo clippy` zero warnings
+- `cargo test` — all 393 pass
+
+---
+
+## Step 2: Move Reset Logic into Aggregate Methods
+
+Extract duplicated reset sequences from `advance_level` and `retry_level`.
+
+### World methods
+
+```rust
+impl World {
+    /// Reset terrain, visibility, enemies for a new level
+    pub fn reset_for_level(&mut self, level: usize) {
+        self.map = Map::level(level);
+        if self.visibility.width() != self.map.width
+            || self.visibility.height() != self.map.height
+        {
+            self.visibility = VisibilityMap::new(self.map.width, self.map.height);
+        }
+        self.visibility.reset();
+        self.enemies = Vec::new();
+        self.activated_torchlights.clear();
+    }
+
+    /// Spawn enemies appropriate for current map
+    pub fn spawn_enemies(&mut self) {
+        self.enemies = self.map.enemy_spawns.iter()
+            .map(|&pos| Enemy::new(pos))
+            .collect();
+        // Level 4: assign patrol areas and HP
+        // ... (move logic from App::spawn_enemies_for_current_level)
+    }
+}
+```
+
+### PlayerState methods
+
+```rust
+impl PlayerState {
+    /// Advance to next level, reset position
+    pub fn advance_level(&mut self, level: usize, start: Position) {
+        self.level = level;
+        self.inner.position = start;
+        self.trail.clear();
+        self.last_checkpoint = None;
+        self.pending_respawn = None;
+    }
+
+    /// Retry current level, full heal
+    pub fn retry_level(&mut self, start: Position) {
+        self.inner.position = start;
+        self.hp = MAX_HP;
+        self.trail.clear();
+        self.last_checkpoint = None;
+        self.pending_respawn = None;
+    }
+}
+```
+
+### App::advance_level becomes
+
+```rust
+pub fn advance_level(&mut self) {
+    let next_level = self.player.level + 1;
+    self.player.advance_level(next_level, self.world.map.start);
+    self.world.reset_for_level(next_level);
+    self.world.spawn_enemies();
+    self.world.update_visibility(self.player.inner.position);
+    self.player_animation = None;
+    self.enemy_animations.clear();
+    self.attack_effects.clear();
+    self.input.clear();
+    self.session.status_message = format!("Level {} — The dungeon shifts around you...", next_level);
+}
+```
+
+### App::retry_level becomes
+
+```rust
+pub fn retry_level(&mut self) {
+    self.player.retry_level(self.world.map.start);
+    self.world.reset_for_level(self.player.level);
+    self.world.spawn_enemies();
+    self.world.update_visibility(self.player.inner.position);
+    self.player_animation = None;
+    self.enemy_animations.clear();
+    self.attack_effects.clear();
+    self.input.clear();
+    self.session.game_state = GameState::Playing;
+    self.session.status_message = format!("Level {} — Try again!", self.player.level);
+}
+```
+
+DRY violation eliminated — each aggregate owns its reset.
+
+### Verification
+
+- `cargo test` — all 393 pass
+- `advance_level` and `retry_level` in game.rs are now ~10 lines each (down from ~25)
+
+---
+
+## Step 3: Move Game Logic into World
+
+Move `update_visibility`, `spawn_enemies_for_current_level`, `enemies_step` from game.rs into World.
+
+### World::update_visibility
+
+```rust
+impl World {
+    pub fn update_visibility(&mut self, player_pos: Position) {
+        self.visibility.demote_visible_to_explored();
+        self.visibility.compute_fov(player_pos, FOV_RADIUS, |p| {
+            self.map.get_tile(p.x, p.y).is_transparent()
+        });
+        for &tp in &self.activated_torchlights {
+            if self.visibility.is_visible(tp) {
+                self.visibility.compute_fov(tp, TORCHLIGHT_FOV_RADIUS, |p| {
+                    self.map.get_tile(p.x, p.y).is_transparent()
+                });
+            }
+        }
+    }
+}
+```
+
+App::update_visibility becomes `self.world.update_visibility(self.player.inner.position)`.
+
+### World::step_enemies
+
+Move the core loop from `game.rs::enemies_step`. Returns collision info so App can coordinate damage:
+
+```rust
+pub struct EnemyCollision {
+    pub enemy_index: usize,
+    pub enemy_pos: Position,
+}
+
+impl World {
+    /// Move all enemies. Returns collisions with player_pos.
+    pub fn step_enemies(&mut self, player_pos: Position) -> Vec<EnemyCollision> {
+        let mut collisions = Vec::new();
+        for (i, enemy) in self.enemies.iter_mut().enumerate() {
+            let moved = if enemy.has_line_of_sight(player_pos, &self.map) {
+                enemy.step_toward_player(player_pos, &self.map)
+            } else {
+                enemy.patrol_step(&self.map)
+            };
+            if moved && enemy.position == player_pos {
+                collisions.push(EnemyCollision { enemy_index: i, enemy_pos: enemy.position });
+            }
+        }
+        collisions
+    }
+}
+```
+
+App coordinates the cross-aggregate flow:
+```rust
+fn enemies_step(&mut self) {
+    let collisions = self.world.step_enemies(self.player.inner.position);
+    for col in collisions {
+        // damage
+        // animation
+        // status message
+        // death/respawn check
+    }
+}
+```
+
+### spawn_enemies_for_current_level → World::spawn_enemies
+
+Already covered in step 2. Move the level-specific enemy configuration logic.
+
+### Verification
+
+- `cargo test` — all 393 pass
+- game.rs shrinks by ~80 lines (enemies_step, update_visibility, spawn logic moved)
+
+---
+
+## Step 4: Extract status_message on PlayerState
+
+### PlayerState::status_message
+
+```rust
+impl PlayerState {
+    /// Status message for the last player action, if any
+    pub fn status_message(&self) -> Option<String> {
+        // Motion discovery messages
+        // Damage/death messages
+        // Checkpoint messages
+        // Respawn messages
+    }
+}
+```
+
+Note: Not all status messages come from PlayerState. Level transition messages come from App coordination. Session still owns the `status_message` field — PlayerState just provides content through its method.
+
+The pattern becomes:
+```rust
+// In game.rs, after a player action:
+if let Some(msg) = self.player.status_message() {
+    self.session.status_message = msg;
+}
+// For coordination-level messages:
+self.session.status_message = format!("Level {}...", self.player.level);
+```
+
+### Verification
+
+- `cargo test` — all 393 pass
+- `status_message` assignments in game.rs reduced from 24 to ~15 direct sets + method calls
+
+---
+
+## Test Impact Summary
+
+| Test file | Step 1 | Step 2 | Step 3 | Step 4 |
+|-----------|--------|--------|--------|--------|
+| common/mod.rs | Heavy (constructors rewrite) | Minor (use new methods) | None | Minor |
+| game.rs (140 tests) | Heavy (accessors) | Minor | Minor | Minor |
+| renderer.rs (53 tests) | Medium (accessors) | None | None | None |
+| player.rs (29 tests) | Medium (accessors) | None | None | Minor |
+| enemy.rs (21 tests) | Light | None | Light (World API) | None |
+| map.rs (46 tests) | None | None | None | None |
+| visibility.rs (29 tests) | Light | None | Light (World API) | None |
+| animation.rs (34 tests) | Light (accessors) | None | None | None |
+| types.rs (25 tests) | Medium (struct changes) | None | None | None |
+| audio.rs (16 tests) | Light | None | None | None |
+
+Step 1 is the big mechanical migration. Steps 2-4 are surgical.

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,4 +1,3 @@
-use std::collections::VecDeque;
 use std::time::Instant;
 
 use bracket_lib::prelude::VirtualKeyCode;
@@ -8,10 +7,9 @@ use crate::animation::{
 };
 use crate::audio::SoundEffect;
 use crate::map::Map;
-use crate::player::Player;
 use crate::types::{
-    App, Enemy, FOV_RADIUS, GameState, MAX_HP, PatrolArea, PauseOption, PendingInput,
-    TORCHLIGHT_FOV_RADIUS, Tile, VimMotion,
+    App, Enemy, FOV_RADIUS, GameState, InputState, MAX_HP, PatrolArea, PauseOption, PendingInput,
+    PlayerState, Session, TORCHLIGHT_FOV_RADIUS, Tile, VimMotion, World,
 };
 use crate::visibility::VisibilityMap;
 
@@ -24,35 +22,17 @@ impl Default for App {
 impl App {
     pub fn new() -> Self {
         let map = Map::new();
-        let player = Player::new(map.start);
+        let world = World::new(map);
+        let start = world.map.start;
         let mut app = Self {
-            map,
-            visibility: VisibilityMap::new(80, 40),
-            player,
+            world,
+            player: PlayerState::new(start),
+            input: InputState::new(),
+            session: Session::new(),
             player_animation: None,
             enemy_animations: Vec::new(),
             attack_effects: Vec::new(),
-            pending_respawn: None,
-            input_queue: Vec::new(),
-            enemies: Vec::new(),
-            hp: MAX_HP,
-            game_state: GameState::Playing,
-            pause_selection: PauseOption::Resume,
-            started: false,
-            pending_input: None,
-            start_time: Instant::now(),
-            elapsed: Default::default(),
-            final_time: None,
-            motion_count: 0,
-            status_message: String::from(
-                "Explore the dungeon and practice the highlighted motions.",
-            ),
-            discovered_motions: Default::default(),
-            trail: VecDeque::new(),
-            level: 1,
             audio: crate::audio::AudioManager::new(),
-            last_checkpoint: None,
-            activated_torchlights: Default::default(),
             #[cfg(debug_assertions)]
             cheat_buf: crate::types::CheatBuffer::new(),
             #[cfg(debug_assertions)]
@@ -63,42 +43,47 @@ impl App {
     }
 
     pub fn refresh_time(&mut self) {
-        if self.started && self.game_state == GameState::Playing {
-            self.elapsed = self.start_time.elapsed();
+        if self.session.started && self.session.game_state == GameState::Playing {
+            self.session.elapsed = self.session.start_time.elapsed();
         }
     }
 
     pub fn current_zone(&self) -> crate::types::Zone {
-        self.map.zone_at(self.player.position)
+        self.world.map.zone_at(self.player.inner.position)
     }
 
     pub fn unique_motions(&self) -> usize {
-        self.discovered_motions.len()
+        self.player.discovered_motions.len()
     }
 
     pub fn update_visibility(&mut self) {
-        if self.visibility.width() != self.map.width || self.visibility.height() != self.map.height
+        if self.world.visibility.width() != self.world.map.width
+            || self.world.visibility.height() != self.world.map.height
         {
-            self.visibility = VisibilityMap::new(self.map.width, self.map.height);
+            self.world.visibility = VisibilityMap::new(self.world.map.width, self.world.map.height);
         }
 
-        let player_position = self.player.position;
-        let map = &self.map;
+        let player_position = self.player.inner.position;
+        let map = &self.world.map;
 
-        self.visibility.demote_visible_to_explored();
-        self.visibility.compute_fov(player_position, FOV_RADIUS, |pos| {
+        self.world.visibility.demote_visible_to_explored();
+        self.world.visibility.compute_fov(player_position, FOV_RADIUS, |pos| {
             matches!(
                 map.get_tile(pos.x, pos.y),
                 Tile::Floor | Tile::Exit | Tile::Obstacle | Tile::Torchlight
             )
         });
 
-        let torchlight_sources: Vec<(crate::types::Position, i32)> =
-            self.activated_torchlights.iter().map(|&pos| (pos, TORCHLIGHT_FOV_RADIUS)).collect();
+        let torchlight_sources: Vec<(crate::types::Position, i32)> = self
+            .world
+            .activated_torchlights
+            .iter()
+            .map(|&pos| (pos, TORCHLIGHT_FOV_RADIUS))
+            .collect();
 
         if !torchlight_sources.is_empty() {
-            let map_ref = &self.map;
-            self.visibility.compute_multi_fov(&torchlight_sources, |pos| {
+            let map_ref = &self.world.map;
+            self.world.visibility.compute_multi_fov(&torchlight_sources, |pos| {
                 matches!(
                     map_ref.get_tile(pos.x, pos.y),
                     Tile::Floor | Tile::Exit | Tile::Obstacle | Tile::Torchlight
@@ -108,19 +93,21 @@ impl App {
     }
 
     fn spawn_enemies_for_current_level(&mut self) {
-        self.enemies = self
+        self.world.enemies = self
+            .world
             .map
             .enemy_spawns
             .iter()
             .enumerate()
             .map(|(i, &pos)| {
                 let patrol_area = self
+                    .world
                     .map
                     .enemy_patrol_areas
                     .get(i)
                     .copied()
                     .unwrap_or_else(|| PatrolArea::point(pos.x, pos.y));
-                if self.level == 4 {
+                if self.player.level == 4 {
                     Enemy { position: pos, glyph: 'e', hp: Some(30), stunned_turns: 0, patrol_area }
                 } else {
                     let mut e = Enemy::new(pos);
@@ -132,50 +119,53 @@ impl App {
     }
 
     pub fn advance_level(&mut self) {
-        self.level += 1;
-        self.map = Map::level(self.level);
-        self.player.position = self.map.start;
+        self.player.level += 1;
+        self.world.map = Map::level(self.player.level);
+        self.player.inner.position = self.world.map.start;
         self.player_animation = None;
         self.enemy_animations.clear();
         self.attack_effects.clear();
-        self.pending_respawn = None;
-        self.input_queue.clear();
+        self.player.pending_respawn = None;
+        self.input.input_queue.clear();
         self.spawn_enemies_for_current_level();
-        self.trail.clear();
-        self.pending_input = None;
-        self.last_checkpoint = None;
-        self.activated_torchlights.clear();
-        if self.visibility.width() != self.map.width || self.visibility.height() != self.map.height
+        self.player.trail.clear();
+        self.input.pending_input = None;
+        self.player.last_checkpoint = None;
+        self.world.activated_torchlights.clear();
+        if self.world.visibility.width() != self.world.map.width
+            || self.world.visibility.height() != self.world.map.height
         {
-            self.visibility = VisibilityMap::new(self.map.width, self.map.height);
+            self.world.visibility = VisibilityMap::new(self.world.map.width, self.world.map.height);
         }
-        self.visibility.reset();
+        self.world.visibility.reset();
         self.update_visibility();
-        self.status_message = format!("Level {} — The dungeon shifts around you...", self.level);
+        self.session.status_message =
+            format!("Level {} — The dungeon shifts around you...", self.player.level);
     }
 
     pub fn retry_level(&mut self) {
-        self.map = Map::level(self.level);
-        self.player.position = self.map.start;
+        self.world.map = Map::level(self.player.level);
+        self.player.inner.position = self.world.map.start;
         self.player_animation = None;
         self.enemy_animations.clear();
         self.attack_effects.clear();
-        self.pending_respawn = None;
-        self.input_queue.clear();
+        self.player.pending_respawn = None;
+        self.input.input_queue.clear();
         self.spawn_enemies_for_current_level();
-        self.hp = MAX_HP;
-        self.trail.clear();
-        self.pending_input = None;
-        self.game_state = GameState::Playing;
-        self.last_checkpoint = None;
-        self.activated_torchlights.clear();
-        if self.visibility.width() != self.map.width || self.visibility.height() != self.map.height
+        self.player.hp = MAX_HP;
+        self.player.trail.clear();
+        self.input.pending_input = None;
+        self.session.game_state = GameState::Playing;
+        self.player.last_checkpoint = None;
+        self.world.activated_torchlights.clear();
+        if self.world.visibility.width() != self.world.map.width
+            || self.world.visibility.height() != self.world.map.height
         {
-            self.visibility = VisibilityMap::new(self.map.width, self.map.height);
+            self.world.visibility = VisibilityMap::new(self.world.map.width, self.world.map.height);
         }
-        self.visibility.reset();
+        self.world.visibility.reset();
         self.update_visibility();
-        self.status_message = format!("Level {} — Try again!", self.level);
+        self.session.status_message = format!("Level {} — Try again!", self.player.level);
     }
 
     #[cfg(debug_assertions)]
@@ -190,28 +180,28 @@ impl App {
 }
 
 pub fn tick(app: &mut App, delta_ms: f64) {
-    if app.game_state == GameState::Paused {
+    if app.session.game_state == GameState::Paused {
         return;
     }
 
-    if app.game_state == GameState::Dying {
+    if app.session.game_state == GameState::Dying {
         app.attack_effects.retain(|e| !e.is_complete());
         if app.attack_effects.is_empty() {
-            let checkpoint = app.pending_respawn.take();
+            let checkpoint = app.player.pending_respawn.take();
             match checkpoint {
                 Some(pos) => {
                     app.enemy_animations.clear();
-                    app.hp = MAX_HP;
-                    app.player.position = pos;
+                    app.player.hp = MAX_HP;
+                    app.player.inner.position = pos;
                     app.player_animation = None;
-                    app.game_state = GameState::Playing;
+                    app.session.game_state = GameState::Playing;
                     push_enemies_off_position(app, pos);
                     app.update_visibility();
-                    app.status_message = String::from("Respawned at checkpoint!");
+                    app.session.status_message = String::from("Respawned at checkpoint!");
                 }
                 None => {
-                    app.game_state = GameState::Lost;
-                    app.status_message = String::from("You were caught! Game over.");
+                    app.session.game_state = GameState::Lost;
+                    app.session.status_message = String::from("You were caught! Game over.");
                 }
             }
             app.attack_effects.clear();
@@ -253,12 +243,12 @@ pub fn tick(app: &mut App, delta_ms: f64) {
         effect.update(delta_ms);
     }
 
-    while app.player_animation.is_none() && !app.input_queue.is_empty() {
-        let (key, shift) = app.input_queue.remove(0);
+    while app.player_animation.is_none() && !app.input.input_queue.is_empty() {
+        let (key, shift) = app.input.input_queue.remove(0);
         handle_key(app, key, shift);
 
-        if matches!(app.game_state, GameState::Quit | GameState::Won | GameState::Dying) {
-            app.input_queue.clear();
+        if matches!(app.session.game_state, GameState::Quit | GameState::Won | GameState::Dying) {
+            app.input.input_queue.clear();
             break;
         }
     }
@@ -346,33 +336,33 @@ fn check_cheat_code(app: &mut App, key: VirtualKeyCode, shift: bool) -> Option<C
 fn apply_cheat(app: &mut App, cheat: CheatCode) {
     match cheat {
         CheatCode::NextLevel => {
-            if app.level < crate::types::TOTAL_LEVELS {
+            if app.player.level < crate::types::TOTAL_LEVELS {
                 app.advance_level();
-                app.status_message = String::from("CHEAT: Level skip!");
+                app.session.status_message = String::from("CHEAT: Level skip!");
             } else {
-                app.game_state = GameState::Won;
-                let final_time = app.start_time.elapsed();
-                app.final_time = Some(final_time);
-                app.elapsed = final_time;
-                app.status_message = String::from("CHEAT: Instant victory!");
+                app.session.game_state = GameState::Won;
+                let final_time = app.session.start_time.elapsed();
+                app.session.final_time = Some(final_time);
+                app.session.elapsed = final_time;
+                app.session.status_message = String::from("CHEAT: Instant victory!");
             }
         }
         CheatCode::GodMode => {
             app.cheat_god_mode = !app.cheat_god_mode;
-            app.status_message = if app.cheat_god_mode {
+            app.session.status_message = if app.cheat_god_mode {
                 String::from("CHEAT: God mode ON")
             } else {
                 String::from("CHEAT: God mode OFF")
             };
         }
         CheatCode::KillEnemies => {
-            app.enemies.clear();
+            app.world.enemies.clear();
             app.enemy_animations.clear();
-            app.status_message = String::from("CHEAT: All enemies eliminated!");
+            app.session.status_message = String::from("CHEAT: All enemies eliminated!");
         }
         CheatCode::Noclip => {
-            app.player.noclip = !app.player.noclip;
-            app.status_message = if app.player.noclip {
+            app.player.inner.noclip = !app.player.inner.noclip;
+            app.session.status_message = if app.player.inner.noclip {
                 String::from("CHEAT: Noclip ON")
             } else {
                 String::from("CHEAT: Noclip OFF")
@@ -382,11 +372,11 @@ fn apply_cheat(app: &mut App, cheat: CheatCode) {
 }
 
 pub fn handle_key(app: &mut App, key: VirtualKeyCode, shift: bool) {
-    if !app.started {
-        app.started = true;
-        app.start_time = Instant::now();
-        app.elapsed = Default::default();
-        app.status_message =
+    if !app.session.started {
+        app.session.started = true;
+        app.session.start_time = Instant::now();
+        app.session.elapsed = Default::default();
+        app.session.status_message =
             String::from("Use hjkl to move. Every motion is available from the start.");
         return;
     }
@@ -397,30 +387,30 @@ pub fn handle_key(app: &mut App, key: VirtualKeyCode, shift: bool) {
         return;
     }
 
-    if app.game_state == GameState::Dying {
+    if app.session.game_state == GameState::Dying {
         return;
     }
 
     if app.player_animation.is_some() {
-        app.input_queue.push((key, shift));
+        app.input.input_queue.push((key, shift));
         return;
     }
 
-    if app.game_state == GameState::Paused {
+    if app.session.game_state == GameState::Paused {
         match key {
             VirtualKeyCode::Escape => {
-                app.game_state = GameState::Playing;
+                app.session.game_state = GameState::Playing;
             }
             VirtualKeyCode::Up | VirtualKeyCode::K if !shift => {
-                app.pause_selection = app.pause_selection.prev();
+                app.session.pause_selection = app.session.pause_selection.prev();
             }
             VirtualKeyCode::Down | VirtualKeyCode::J if !shift => {
-                app.pause_selection = app.pause_selection.next();
+                app.session.pause_selection = app.session.pause_selection.next();
             }
-            VirtualKeyCode::Return => match app.pause_selection {
-                PauseOption::Resume => app.game_state = GameState::Playing,
+            VirtualKeyCode::Return => match app.session.pause_selection {
+                PauseOption::Resume => app.session.game_state = GameState::Playing,
                 PauseOption::RetryLevel => app.retry_level(),
-                PauseOption::QuitGame => app.game_state = GameState::Quit,
+                PauseOption::QuitGame => app.session.game_state = GameState::Quit,
             },
             _ => {}
         }
@@ -428,24 +418,24 @@ pub fn handle_key(app: &mut App, key: VirtualKeyCode, shift: bool) {
     }
 
     if matches!(key, VirtualKeyCode::Escape) || (key == VirtualKeyCode::Q && !shift) {
-        app.input_queue.clear();
-        app.pending_input = None;
-        app.game_state = GameState::Paused;
-        app.pause_selection = PauseOption::Resume;
+        app.input.input_queue.clear();
+        app.input.pending_input = None;
+        app.session.game_state = GameState::Paused;
+        app.session.pause_selection = PauseOption::Resume;
         return;
     }
 
-    if app.game_state == GameState::Won {
+    if app.session.game_state == GameState::Won {
         return;
     }
 
-    if app.game_state == GameState::Lost {
+    if app.session.game_state == GameState::Lost {
         app.retry_level();
         return;
     }
 
-    if let Some(pending) = app.pending_input {
-        app.pending_input = None;
+    if let Some(pending) = app.input.pending_input {
+        app.input.pending_input = None;
         match pending {
             PendingInput::Find => {
                 if let Some(target) = vkey_to_char(key, shift) {
@@ -461,14 +451,16 @@ pub fn handle_key(app: &mut App, key: VirtualKeyCode, shift: bool) {
                 if key == VirtualKeyCode::D && !shift {
                     execute_motion(app, VimMotion::DeleteLine, None);
                 } else {
-                    app.status_message = String::from("dd needs a second d. Command cancelled.");
+                    app.session.status_message =
+                        String::from("dd needs a second d. Command cancelled.");
                 }
             }
             PendingInput::GotoLine => {
                 if key == VirtualKeyCode::G && !shift {
                     execute_motion(app, VimMotion::GotoLine, None);
                 } else {
-                    app.status_message = String::from("gg needs a second g. Command cancelled.");
+                    app.session.status_message =
+                        String::from("gg needs a second g. Command cancelled.");
                 }
             }
         }
@@ -483,8 +475,8 @@ pub fn handle_key(app: &mut App, key: VirtualKeyCode, shift: bool) {
     match parse_motion(key, shift) {
         Some(ParsedInput::Immediate(motion)) => execute_motion(app, motion, None),
         Some(ParsedInput::AwaitTarget(pending)) => {
-            app.pending_input = Some(pending);
-            app.status_message = match pending {
+            app.input.pending_input = Some(pending);
+            app.session.status_message = match pending {
                 PendingInput::Find => {
                     String::from("Find: type the target tile character (., #, >, ▒).")
                 }
@@ -528,11 +520,18 @@ fn parse_motion(key: VirtualKeyCode, shift: bool) -> Option<ParsedInput> {
 fn push_enemies_off_position(app: &mut App, pos: crate::types::Position) {
     use std::collections::{HashSet, VecDeque};
     let directions: [(isize, isize); 4] = [(-1, 0), (1, 0), (0, -1), (0, 1)];
-    let mut new_positions: Vec<Option<crate::types::Position>> = vec![None; app.enemies.len()];
+    let mut new_positions: Vec<Option<crate::types::Position>> =
+        vec![None; app.world.enemies.len()];
     let mut claimed: HashSet<crate::types::Position> = HashSet::new();
 
-    let enemies_on_pos: Vec<usize> =
-        app.enemies.iter().enumerate().filter(|(_, e)| e.position == pos).map(|(i, _)| i).collect();
+    let enemies_on_pos: Vec<usize> = app
+        .world
+        .enemies
+        .iter()
+        .enumerate()
+        .filter(|(_, e)| e.position == pos)
+        .map(|(i, _)| i)
+        .collect();
 
     if enemies_on_pos.is_empty() {
         return;
@@ -544,7 +543,10 @@ fn push_enemies_off_position(app: &mut App, pos: crate::types::Position) {
     for (dx, dy) in &directions {
         let nx = (pos.x as isize + dx) as usize;
         let ny = (pos.y as isize + dy) as usize;
-        if nx < app.map.width && ny < app.map.height && app.map.is_passable(nx, ny) {
+        if nx < app.world.map.width
+            && ny < app.world.map.height
+            && app.world.map.is_passable(nx, ny)
+        {
             let neighbor = crate::types::Position { x: nx, y: ny };
             if visited.insert(neighbor) {
                 bfs.push_back(neighbor);
@@ -559,11 +561,11 @@ fn push_enemies_off_position(app: &mut App, pos: crate::types::Position) {
             None => break,
         };
 
-        if candidate.x < app.map.width
-            && candidate.y < app.map.height
-            && app.map.is_passable(candidate.x, candidate.y)
+        if candidate.x < app.world.map.width
+            && candidate.y < app.world.map.height
+            && app.world.map.is_passable(candidate.x, candidate.y)
             && !claimed.contains(&candidate)
-            && !app.enemies.iter().any(|e| e.position == candidate)
+            && !app.world.enemies.iter().any(|e| e.position == candidate)
         {
             let idx = enemies_on_pos[assigned];
             new_positions[idx] = Some(candidate);
@@ -574,7 +576,10 @@ fn push_enemies_off_position(app: &mut App, pos: crate::types::Position) {
         for (dx, dy) in &directions {
             let nx = (candidate.x as isize + dx) as usize;
             let ny = (candidate.y as isize + dy) as usize;
-            if nx < app.map.width && ny < app.map.height && app.map.is_passable(nx, ny) {
+            if nx < app.world.map.width
+                && ny < app.world.map.height
+                && app.world.map.is_passable(nx, ny)
+            {
                 let neighbor = crate::types::Position { x: nx, y: ny };
                 if visited.insert(neighbor) {
                     bfs.push_back(neighbor);
@@ -583,7 +588,7 @@ fn push_enemies_off_position(app: &mut App, pos: crate::types::Position) {
         }
     }
 
-    for (i, enemy) in app.enemies.iter_mut().enumerate() {
+    for (i, enemy) in app.world.enemies.iter_mut().enumerate() {
         if let Some(new_pos) = new_positions[i] {
             enemy.position = new_pos;
         }
@@ -591,16 +596,17 @@ fn push_enemies_off_position(app: &mut App, pos: crate::types::Position) {
 }
 
 fn enemies_step(app: &mut App) {
-    let player_pos = app.player.position;
-    let mut prior_animations = vec![None; app.enemies.len()];
+    let player_pos = app.player.inner.position;
+    let mut prior_animations = vec![None; app.world.enemies.len()];
     for (enemy_index, animation) in std::mem::take(&mut app.enemy_animations) {
         if enemy_index < prior_animations.len() {
             prior_animations[enemy_index] = Some(animation);
         }
     }
     let old_positions: Vec<crate::types::Position> =
-        app.enemies.iter().map(|enemy| enemy.position).collect();
+        app.world.enemies.iter().map(|enemy| enemy.position).collect();
     let old_visual_positions: Vec<(f64, f64)> = app
+        .world
         .enemies
         .iter()
         .enumerate()
@@ -611,14 +617,14 @@ fn enemies_step(app: &mut App) {
         })
         .collect();
 
-    for enemy in &mut app.enemies {
+    for enemy in &mut app.world.enemies {
         if enemy.stunned_turns > 0 {
             enemy.stunned_turns -= 1;
         } else {
-            let moved = if enemy.has_line_of_sight(player_pos, &app.map) {
-                enemy.step_toward_player(player_pos, &app.map)
+            let moved = if enemy.has_line_of_sight(player_pos, &app.world.map) {
+                enemy.step_toward_player(player_pos, &app.world.map)
             } else {
-                enemy.patrol_step(&app.map)
+                enemy.patrol_step(&app.world.map)
             };
             if moved {
                 app.audio.play(SoundEffect::EnemyStep);
@@ -626,32 +632,35 @@ fn enemies_step(app: &mut App) {
         }
     }
 
-    let player_pos = app.player.position;
+    let player_pos = app.player.inner.position;
     let invincible = app.is_invincible();
-    let mut remaining_enemies = Vec::with_capacity(app.enemies.len());
+    let mut remaining_enemies = Vec::with_capacity(app.world.enemies.len());
     let mut next_animations = Vec::new();
-    for (old_index, ((old_position, old_visual_position), enemy)) in
-        old_positions.into_iter().zip(old_visual_positions).zip(app.enemies.drain(..)).enumerate()
+    for (old_index, ((old_position, old_visual_position), enemy)) in old_positions
+        .into_iter()
+        .zip(old_visual_positions)
+        .zip(app.world.enemies.drain(..))
+        .enumerate()
     {
         if enemy.position == player_pos
             && enemy.stunned_turns == 0
-            && app.game_state == GameState::Playing
+            && app.session.game_state == GameState::Playing
             && !invincible
         {
             app.audio.play(SoundEffect::Damage);
-            app.hp -= 10;
+            app.player.hp -= 10;
             app.attack_effects.push(AttackEffect::new(
                 AttackEffectKind::EnemyHit,
                 player_pos.x,
                 player_pos.y,
             ));
-            if app.hp <= 0 {
-                app.hp = 0;
-                app.input_queue.clear();
-                app.game_state = GameState::Dying;
-                app.pending_respawn = app.last_checkpoint;
+            if app.player.hp <= 0 {
+                app.player.hp = 0;
+                app.input.input_queue.clear();
+                app.session.game_state = GameState::Dying;
+                app.player.pending_respawn = app.player.last_checkpoint;
             } else {
-                app.status_message = format!("Hit! {} HP remaining.", app.hp);
+                app.session.status_message = format!("Hit! {} HP remaining.", app.player.hp);
             }
             if enemy.hp.is_some() {
                 let new_index = remaining_enemies.len();
@@ -687,113 +696,119 @@ fn enemies_step(app: &mut App) {
         }
     }
 
-    app.enemies = remaining_enemies;
+    app.world.enemies = remaining_enemies;
     app.enemy_animations = next_animations;
 }
 
 fn execute_motion(app: &mut App, motion: VimMotion, target: Option<char>) {
-    let old_pos = app.player.position;
-    let old_zone = app.map.zone_at(old_pos);
+    let old_pos = app.player.inner.position;
+    let old_zone = app.world.map.zone_at(old_pos);
 
     let activated = match motion {
         VimMotion::DeleteLine => {
-            app.status_message = String::from("dd clears the nearest obstacle on your row.");
-            app.player.handle_motion(motion, target, &mut app.map)
+            app.session.status_message =
+                String::from("dd clears the nearest obstacle on your row.");
+            app.player.inner.handle_motion(motion, target, &mut app.world.map)
         }
         VimMotion::Find => {
             let message = target
                 .map(|ch| format!("f{ch} searches forward for the next matching tile."))
                 .unwrap_or_else(|| String::from("Find motion ready."));
-            app.status_message = message;
-            app.player.handle_motion(motion, target, &mut app.map)
+            app.session.status_message = message;
+            app.player.inner.handle_motion(motion, target, &mut app.world.map)
         }
         VimMotion::Till => {
             let message = target
                 .map(|ch| format!("t{ch} stops one tile before the next match."))
                 .unwrap_or_else(|| String::from("Till motion ready."));
-            app.status_message = message;
-            app.player.handle_motion(motion, target, &mut app.map)
+            app.session.status_message = message;
+            app.player.inner.handle_motion(motion, target, &mut app.world.map)
         }
         _ => {
-            app.status_message = format!("{} — {}", motion.key_label(), motion.description());
-            app.player.handle_motion(motion, target, &mut app.map)
+            app.session.status_message =
+                format!("{} — {}", motion.key_label(), motion.description());
+            app.player.inner.handle_motion(motion, target, &mut app.world.map)
         }
     };
 
-    app.motion_count += 1;
-    app.discovered_motions.insert(motion);
+    app.player.motion_count += 1;
+    app.player.discovered_motions.insert(motion);
     app.refresh_time();
 
-    if activated && old_pos != app.player.position {
+    if activated && old_pos != app.player.inner.position {
         app.player_animation = Some(AnimationState::new(
             PLAYER_MOVE_MS,
             (old_pos.x as f64, old_pos.y as f64),
-            (app.player.position.x as f64, app.player.position.y as f64),
+            (app.player.inner.position.x as f64, app.player.inner.position.y as f64),
         ));
-        app.trail.push_front(old_pos);
-        if app.trail.len() > crate::types::TRAIL_MAX {
-            app.trail.pop_back();
+        app.player.trail.push_front(old_pos);
+        if app.player.trail.len() > crate::types::TRAIL_MAX {
+            app.player.trail.pop_back();
         }
         app.audio.play(SoundEffect::Movement);
-        let new_zone = app.map.zone_at(app.player.position);
+        let new_zone = app.world.map.zone_at(app.player.inner.position);
         if new_zone != old_zone {
             app.audio.play(SoundEffect::ZoneEntry);
         }
     }
 
     if !activated {
-        app.status_message.push_str(" No valid destination from here.");
+        app.session.status_message.push_str(" No valid destination from here.");
     }
 
-    if app.map.get_tile(app.player.position.x, app.player.position.y) == Tile::Torchlight {
-        let torch_pos = app.player.position;
-        if !app.activated_torchlights.contains(&torch_pos) {
-            app.activated_torchlights.insert(torch_pos);
-            app.last_checkpoint = Some(torch_pos);
-            app.status_message = String::from("Checkpoint activated! Torchlight lit.");
+    if app.world.map.get_tile(app.player.inner.position.x, app.player.inner.position.y)
+        == Tile::Torchlight
+    {
+        let torch_pos = app.player.inner.position;
+        if !app.world.activated_torchlights.contains(&torch_pos) {
+            app.world.activated_torchlights.insert(torch_pos);
+            app.player.last_checkpoint = Some(torch_pos);
+            app.session.status_message = String::from("Checkpoint activated! Torchlight lit.");
         }
     }
 
-    if app.map.get_tile(app.player.position.x, app.player.position.y) == Tile::Exit {
-        if app.level < crate::types::TOTAL_LEVELS {
+    if app.world.map.get_tile(app.player.inner.position.x, app.player.inner.position.y)
+        == Tile::Exit
+    {
+        if app.player.level < crate::types::TOTAL_LEVELS {
             app.audio.play(SoundEffect::LevelComplete);
             app.advance_level();
         } else {
             app.audio.play(SoundEffect::Victory);
-            app.game_state = GameState::Won;
-            let final_time = app.start_time.elapsed();
-            app.final_time = Some(final_time);
-            app.elapsed = final_time;
-            app.status_message = String::from("You conquered all levels of the dungeon!");
+            app.session.game_state = GameState::Won;
+            let final_time = app.session.start_time.elapsed();
+            app.session.final_time = Some(final_time);
+            app.session.elapsed = final_time;
+            app.session.status_message = String::from("You conquered all levels of the dungeon!");
         }
         return;
     }
 
-    if activated && old_pos != app.player.position {
+    if activated && old_pos != app.player.inner.position {
         app.update_visibility();
         enemies_step(app);
     }
 }
 
 fn handle_melee_attack(app: &mut App) {
-    let facing = match app.player.last_direction {
+    let facing = match app.player.inner.last_direction {
         Some(dir) => dir,
         None => {
-            app.status_message = String::from("No direction — move first.");
+            app.session.status_message = String::from("No direction — move first.");
             return;
         }
     };
 
     let (dx, dy) = facing.delta();
-    let target_x = (app.player.position.x as isize + dx) as usize;
-    let target_y = (app.player.position.y as isize + dy) as usize;
+    let target_x = (app.player.inner.position.x as isize + dx) as usize;
+    let target_y = (app.player.inner.position.y as isize + dy) as usize;
 
     let enemy_index =
-        app.enemies.iter().position(|e| e.position.x == target_x && e.position.y == target_y);
+        app.world.enemies.iter().position(|e| e.position.x == target_x && e.position.y == target_y);
 
     match enemy_index {
         Some(idx) => {
-            let enemy_hp = app.enemies[idx].hp;
+            let enemy_hp = app.world.enemies[idx].hp;
             match enemy_hp {
                 Some(hp) if hp > 0 => {
                     app.attack_effects.push(AttackEffect::new(
@@ -803,25 +818,25 @@ fn handle_melee_attack(app: &mut App) {
                     ));
                     let new_hp = hp - 10;
                     if new_hp <= 0 {
-                        app.enemies.remove(idx);
-                        app.status_message = String::from("Enemy defeated!");
+                        app.world.enemies.remove(idx);
+                        app.session.status_message = String::from("Enemy defeated!");
                     } else {
-                        app.enemies[idx].hp = Some(new_hp);
-                        app.enemies[idx].stunned_turns = 1;
-                        app.status_message = format!("Hit! Enemy HP: {}", new_hp);
+                        app.world.enemies[idx].hp = Some(new_hp);
+                        app.world.enemies[idx].stunned_turns = 1;
+                        app.session.status_message = format!("Hit! Enemy HP: {}", new_hp);
                     }
-                    app.motion_count += 1;
+                    app.player.motion_count += 1;
                     app.refresh_time();
                     enemies_step(app);
                 }
                 _ => {
-                    app.status_message = String::from("Can't attack this enemy.");
+                    app.session.status_message = String::from("Can't attack this enemy.");
                 }
             }
         }
         None => {
-            app.status_message = String::from("Nothing there.");
-            app.motion_count += 1;
+            app.session.status_message = String::from("Nothing there.");
+            app.player.motion_count += 1;
             app.refresh_time();
             enemies_step(app);
         }

--- a/src/game.rs
+++ b/src/game.rs
@@ -8,10 +8,9 @@ use crate::animation::{
 use crate::audio::SoundEffect;
 use crate::map::Map;
 use crate::types::{
-    App, FOV_RADIUS, GameState, InputState, MAX_HP, PauseOption, PendingInput, PlayerState,
-    Session, TORCHLIGHT_FOV_RADIUS, Tile, VimMotion, World,
+    App, GameState, InputState, MAX_HP, PauseOption, PendingInput, PlayerState, Session, Tile,
+    VimMotion, World,
 };
-use crate::visibility::VisibilityMap;
 
 impl Default for App {
     fn default() -> Self {
@@ -57,39 +56,7 @@ impl App {
     }
 
     pub fn update_visibility(&mut self) {
-        if self.world.visibility.width() != self.world.map.width
-            || self.world.visibility.height() != self.world.map.height
-        {
-            self.world.visibility = VisibilityMap::new(self.world.map.width, self.world.map.height);
-        }
-
-        let player_position = self.player.inner.position;
-        let map = &self.world.map;
-
-        self.world.visibility.demote_visible_to_explored();
-        self.world.visibility.compute_fov(player_position, FOV_RADIUS, |pos| {
-            matches!(
-                map.get_tile(pos.x, pos.y),
-                Tile::Floor | Tile::Exit | Tile::Obstacle | Tile::Torchlight
-            )
-        });
-
-        let torchlight_sources: Vec<(crate::types::Position, i32)> = self
-            .world
-            .activated_torchlights
-            .iter()
-            .map(|&pos| (pos, TORCHLIGHT_FOV_RADIUS))
-            .collect();
-
-        if !torchlight_sources.is_empty() {
-            let map_ref = &self.world.map;
-            self.world.visibility.compute_multi_fov(&torchlight_sources, |pos| {
-                matches!(
-                    map_ref.get_tile(pos.x, pos.y),
-                    Tile::Floor | Tile::Exit | Tile::Obstacle | Tile::Torchlight
-                )
-            });
-        }
+        self.world.update_visibility(self.player.inner.position);
     }
 
     pub fn advance_level(&mut self) {

--- a/src/game.rs
+++ b/src/game.rs
@@ -578,7 +578,7 @@ fn enemies_step(app: &mut App) {
                 app.session.game_state = GameState::Dying;
                 app.player.pending_respawn = app.player.last_checkpoint;
             } else {
-                app.session.status_message = format!("Hit! {} HP remaining.", app.player.hp);
+                app.session.status_message = app.player.damage_feedback();
             }
             if enemy.hp.is_some() {
                 let new_index = remaining_enemies.len();
@@ -622,31 +622,9 @@ fn execute_motion(app: &mut App, motion: VimMotion, target: Option<char>) {
     let old_pos = app.player.inner.position;
     let old_zone = app.world.map.zone_at(old_pos);
 
-    let activated = match motion {
-        VimMotion::DeleteLine => {
-            app.session.status_message =
-                String::from("dd clears the nearest obstacle on your row.");
-            app.player.inner.handle_motion(motion, target, &mut app.world.map)
-        }
-        VimMotion::Find => {
-            let message = target
-                .map(|ch| format!("f{ch} searches forward for the next matching tile."))
-                .unwrap_or_else(|| String::from("Find motion ready."));
-            app.session.status_message = message;
-            app.player.inner.handle_motion(motion, target, &mut app.world.map)
-        }
-        VimMotion::Till => {
-            let message = target
-                .map(|ch| format!("t{ch} stops one tile before the next match."))
-                .unwrap_or_else(|| String::from("Till motion ready."));
-            app.session.status_message = message;
-            app.player.inner.handle_motion(motion, target, &mut app.world.map)
-        }
-        _ => {
-            app.session.status_message =
-                format!("{} — {}", motion.key_label(), motion.description());
-            app.player.inner.handle_motion(motion, target, &mut app.world.map)
-        }
+    let activated = {
+        app.session.status_message = app.player.motion_feedback(motion, target);
+        app.player.inner.handle_motion(motion, target, &mut app.world.map)
     };
 
     app.player.motion_count += 1;

--- a/src/game.rs
+++ b/src/game.rs
@@ -8,8 +8,8 @@ use crate::animation::{
 use crate::audio::SoundEffect;
 use crate::map::Map;
 use crate::types::{
-    App, Enemy, FOV_RADIUS, GameState, InputState, MAX_HP, PatrolArea, PauseOption, PendingInput,
-    PlayerState, Session, TORCHLIGHT_FOV_RADIUS, Tile, VimMotion, World,
+    App, FOV_RADIUS, GameState, InputState, MAX_HP, PauseOption, PendingInput, PlayerState,
+    Session, TORCHLIGHT_FOV_RADIUS, Tile, VimMotion, World,
 };
 use crate::visibility::VisibilityMap;
 
@@ -92,78 +92,29 @@ impl App {
         }
     }
 
-    fn spawn_enemies_for_current_level(&mut self) {
-        self.world.enemies = self
-            .world
-            .map
-            .enemy_spawns
-            .iter()
-            .enumerate()
-            .map(|(i, &pos)| {
-                let patrol_area = self
-                    .world
-                    .map
-                    .enemy_patrol_areas
-                    .get(i)
-                    .copied()
-                    .unwrap_or_else(|| PatrolArea::point(pos.x, pos.y));
-                if self.player.level == 4 {
-                    Enemy { position: pos, glyph: 'e', hp: Some(30), stunned_turns: 0, patrol_area }
-                } else {
-                    let mut e = Enemy::new(pos);
-                    e.patrol_area = patrol_area;
-                    e
-                }
-            })
-            .collect();
-    }
-
     pub fn advance_level(&mut self) {
-        self.player.level += 1;
-        self.world.map = Map::level(self.player.level);
-        self.player.inner.position = self.world.map.start;
+        let next_level = self.player.level + 1;
+        self.world.reset_for_level(next_level);
+        self.world.spawn_enemies(next_level);
+        self.player.advance_level(next_level, self.world.map.start);
         self.player_animation = None;
         self.enemy_animations.clear();
         self.attack_effects.clear();
-        self.player.pending_respawn = None;
-        self.input.input_queue.clear();
-        self.spawn_enemies_for_current_level();
-        self.player.trail.clear();
-        self.input.pending_input = None;
-        self.player.last_checkpoint = None;
-        self.world.activated_torchlights.clear();
-        if self.world.visibility.width() != self.world.map.width
-            || self.world.visibility.height() != self.world.map.height
-        {
-            self.world.visibility = VisibilityMap::new(self.world.map.width, self.world.map.height);
-        }
-        self.world.visibility.reset();
+        self.input.clear();
         self.update_visibility();
         self.session.status_message =
-            format!("Level {} — The dungeon shifts around you...", self.player.level);
+            format!("Level {} — The dungeon shifts around you...", next_level);
     }
 
     pub fn retry_level(&mut self) {
-        self.world.map = Map::level(self.player.level);
-        self.player.inner.position = self.world.map.start;
+        self.world.reset_for_level(self.player.level);
+        self.world.spawn_enemies(self.player.level);
+        self.player.retry_level(self.world.map.start);
         self.player_animation = None;
         self.enemy_animations.clear();
         self.attack_effects.clear();
-        self.player.pending_respawn = None;
-        self.input.input_queue.clear();
-        self.spawn_enemies_for_current_level();
-        self.player.hp = MAX_HP;
-        self.player.trail.clear();
-        self.input.pending_input = None;
+        self.input.clear();
         self.session.game_state = GameState::Playing;
-        self.player.last_checkpoint = None;
-        self.world.activated_torchlights.clear();
-        if self.world.visibility.width() != self.world.map.width
-            || self.world.visibility.height() != self.world.map.height
-        {
-            self.world.visibility = VisibilityMap::new(self.world.map.width, self.world.map.height);
-        }
-        self.world.visibility.reset();
         self.update_visibility();
         self.session.status_message = format!("Level {} — Try again!", self.player.level);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ impl GameState for AppWrapper {
             game::handle_key(&mut self.app, key, ctx.shift);
         }
 
-        if self.app.game_state == vim_rogue::types::GameState::Quit {
+        if self.app.session.game_state == vim_rogue::types::GameState::Quit {
             ctx.quit();
             return;
         }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -19,28 +19,28 @@ pub fn render(ctx: &mut BTerm, app: &App) {
         return;
     }
 
-    if !app.started {
+    if !app.session.started {
         render_title(ctx);
         return;
     }
 
-    if app.game_state == GameState::Won {
+    if app.session.game_state == GameState::Won {
         render_win(ctx, app);
         return;
     }
 
-    if app.game_state == GameState::Lost {
+    if app.session.game_state == GameState::Lost {
         render_lost(ctx, app);
         return;
     }
 
-    if app.game_state == GameState::Paused {
+    if app.session.game_state == GameState::Paused {
         render_gameplay(ctx, app);
         render_pause_overlay(ctx, app);
         return;
     }
 
-    if app.game_state == GameState::Dying {
+    if app.session.game_state == GameState::Dying {
         render_gameplay(ctx, app);
         return;
     }
@@ -114,23 +114,23 @@ fn render_map_viewport(ctx: &mut BTerm, app: &App, map_width: i32) {
     let mut left = player_draw_pos.x.saturating_sub(half_w);
     let mut top = player_draw_pos.y.saturating_sub(half_h);
 
-    if left + view_width > app.map.width {
-        left = app.map.width.saturating_sub(view_width);
+    if left + view_width > app.world.map.width {
+        left = app.world.map.width.saturating_sub(view_width);
     }
-    if top + view_height > app.map.height {
-        top = app.map.height.saturating_sub(view_height);
+    if top + view_height > app.world.map.height {
+        top = app.world.map.height.saturating_sub(view_height);
     }
 
-    let trail_positions: Vec<crate::types::Position> = app.trail.iter().copied().collect();
+    let trail_positions: Vec<crate::types::Position> = app.player.trail.iter().copied().collect();
 
     for screen_y in 0..view_height {
         let map_y = top + screen_y;
-        if map_y >= app.map.height {
+        if map_y >= app.world.map.height {
             break;
         }
         for screen_x in 0..view_width {
             let map_x = left + screen_x;
-            if map_x >= app.map.width {
+            if map_x >= app.world.map.width {
                 break;
             }
 
@@ -142,7 +142,7 @@ fn render_map_viewport(ctx: &mut BTerm, app: &App, map_width: i32) {
                 continue;
             }
 
-            let vis = app.visibility.get(Position { x: map_x, y: map_y });
+            let vis = app.world.visibility.get(Position { x: map_x, y: map_y });
 
             if vis == VisibilityState::Hidden {
                 ctx.print_color(draw_x, draw_y, black, black, " ");
@@ -167,11 +167,12 @@ fn render_map_viewport(ctx: &mut BTerm, app: &App, map_width: i32) {
                 }
             }
 
-            let tile = app.map.get_tile(map_x, map_y);
-            let zone = app.map.zone_at(Position { x: map_x, y: map_y });
-            let wall_glyph = wall_display_glyph(map_x, map_y, &app.map);
+            let tile = app.world.map.get_tile(map_x, map_y);
+            let zone = app.world.map.zone_at(Position { x: map_x, y: map_y });
+            let wall_glyph = wall_display_glyph(map_x, map_y, &app.world.map);
 
-            if let Some((glyph, fg)) = tile_fog_appearance(tile, zone, vis, app.elapsed, wall_glyph)
+            if let Some((glyph, fg)) =
+                tile_fog_appearance(tile, zone, vis, app.session.elapsed, wall_glyph)
             {
                 ctx.print_color(draw_x, draw_y, fg, black, glyph.to_string());
             }
@@ -198,16 +199,17 @@ pub fn visual_player_position(app: &App) -> Position {
     let (x, y) = app
         .player_animation
         .map(|animation| animation.current_position())
-        .unwrap_or((app.player.position.x as f64, app.player.position.y as f64));
+        .unwrap_or((app.player.inner.position.x as f64, app.player.inner.position.y as f64));
 
     Position {
-        x: x.round().clamp(0.0, app.map.width.saturating_sub(1) as f64) as usize,
-        y: y.round().clamp(0.0, app.map.height.saturating_sub(1) as f64) as usize,
+        x: x.round().clamp(0.0, app.world.map.width.saturating_sub(1) as f64) as usize,
+        y: y.round().clamp(0.0, app.world.map.height.saturating_sub(1) as f64) as usize,
     }
 }
 
 pub fn visual_enemy_positions(app: &App) -> Vec<Position> {
-    app.enemies
+    app.world
+        .enemies
         .iter()
         .enumerate()
         .map(|(enemy_index, enemy)| {
@@ -220,8 +222,8 @@ pub fn visual_enemy_positions(app: &App) -> Vec<Position> {
                 .unwrap_or((enemy.position.x as f64, enemy.position.y as f64));
 
             Position {
-                x: x.round().clamp(0.0, app.map.width.saturating_sub(1) as f64) as usize,
-                y: y.round().clamp(0.0, app.map.height.saturating_sub(1) as f64) as usize,
+                x: x.round().clamp(0.0, app.world.map.width.saturating_sub(1) as f64) as usize,
+                y: y.round().clamp(0.0, app.world.map.height.saturating_sub(1) as f64) as usize,
             }
         })
         .collect()
@@ -254,13 +256,25 @@ fn render_sidebar(ctx: &mut BTerm, app: &App, sidebar_x: i32) {
     ctx.print_color(sidebar_x, y, zone_color, black, zone.title());
     y += 2;
 
-    ctx.print_color(sidebar_x, y, white, black, format!("Level: {} / {}", app.level, TOTAL_LEVELS));
+    ctx.print_color(
+        sidebar_x,
+        y,
+        white,
+        black,
+        format!("Level: {} / {}", app.player.level, TOTAL_LEVELS),
+    );
     y += 1;
-    ctx.print_color(sidebar_x, y, white, black, format!("Time:  {}", format_duration(app.elapsed)));
+    ctx.print_color(
+        sidebar_x,
+        y,
+        white,
+        black,
+        format!("Time:  {}", format_duration(app.session.elapsed)),
+    );
     y += 1;
-    ctx.print_color(sidebar_x, y, white, black, format!("Moves: {}", app.motion_count));
+    ctx.print_color(sidebar_x, y, white, black, format!("Moves: {}", app.player.motion_count));
     y += 1;
-    let hp_ratio = app.hp as f32 / MAX_HP as f32;
+    let hp_ratio = app.player.hp as f32 / MAX_HP as f32;
     let hp_filled = (hp_ratio * 10.0).round() as usize;
     let hp_color = if hp_ratio > 0.5 {
         RGB::named(GREEN)
@@ -269,7 +283,7 @@ fn render_sidebar(ctx: &mut BTerm, app: &App, sidebar_x: i32) {
     } else {
         RGB::named(RED)
     };
-    let hp_text = format!("HP: {}/{}", app.hp, MAX_HP);
+    let hp_text = format!("HP: {}/{}", app.player.hp, MAX_HP);
     ctx.print_color(sidebar_x, y, hp_color, black, &hp_text);
     y += 1;
     let mut bar = String::with_capacity(12);
@@ -298,7 +312,7 @@ fn render_sidebar(ctx: &mut BTerm, app: &App, sidebar_x: i32) {
             if y >= 47 {
                 break;
             }
-            let used = app.player.used_motions.contains(motion);
+            let used = app.player.inner.used_motions.contains(motion);
             let marker = if used { "✓" } else { "·" };
             let color = if used { green } else { dark_gray };
             let label = format!("{} {:<7} {}", marker, motion.key_label(), motion.display_name());
@@ -314,16 +328,16 @@ fn render_sidebar(ctx: &mut BTerm, app: &App, sidebar_x: i32) {
     }
     if y < 48 {
         let max_width = (80 - sidebar_x) as usize;
-        let msg = if app.status_message.len() > max_width {
-            &app.status_message[..max_width]
+        let msg = if app.session.status_message.len() > max_width {
+            &app.session.status_message[..max_width]
         } else {
-            &app.status_message
+            &app.session.status_message
         };
         ctx.print_color(sidebar_x, y, dark_gray, black, msg);
         y += 2;
     }
 
-    if let Some(pending) = app.pending_input
+    if let Some(pending) = app.input.pending_input
         && y < 49
     {
         let prompt = match pending {
@@ -390,14 +404,14 @@ fn render_minimap(ctx: &mut BTerm, app: &App, x: i32, start_y: i32, y_out: &mut 
         for mx in 0..MINIMAP_WIDTH {
             let (map_x, map_y) = minimap_map_coords(mx, my);
             let pos = Position { x: map_x, y: map_y };
-            let vis = app.visibility.get(pos);
+            let vis = app.world.visibility.get(pos);
 
             if vis == VisibilityState::Hidden {
                 continue;
             }
 
-            let tile = app.map.get_tile(map_x, map_y);
-            let zone = app.map.zone_at(pos);
+            let tile = app.world.map.get_tile(map_x, map_y);
+            let zone = app.world.map.zone_at(pos);
 
             let (glyph, color) = match tile {
                 Tile::Wall => ('█', dim_color(zone_wall_color(zone), 0.6)),
@@ -420,7 +434,7 @@ fn render_minimap(ctx: &mut BTerm, app: &App, x: i32, start_y: i32, y_out: &mut 
         }
     }
 
-    let (px, py) = minimap_player_pos(app.player.position.x, app.player.position.y);
+    let (px, py) = minimap_player_pos(app.player.inner.position.x, app.player.inner.position.y);
     ctx.print_color(x + 1 + px, mm_y + 1 + py, RGB::named(GREEN), black, "@");
 
     *y_out = bottom_y + 1;
@@ -560,10 +574,10 @@ fn render_win(ctx: &mut BTerm, app: &App) {
     }
     y += 1;
 
-    let duration = format_duration(app.final_time.unwrap_or(app.elapsed));
+    let duration = format_duration(app.session.final_time.unwrap_or(app.session.elapsed));
     let stats = format!(
         "  Level: {} / {}    Time: {}    Moves: {}",
-        app.level, TOTAL_LEVELS, duration, app.motion_count
+        app.player.level, TOTAL_LEVELS, duration, app.player.motion_count
     );
     ctx.print_color(center_x(stats.len()), y, white, black, &stats);
     y += 2;
@@ -574,7 +588,8 @@ fn render_win(ctx: &mut BTerm, app: &App) {
 
     for (zone, motions) in phase_definitions() {
         let total = motions.len();
-        let discovered = motions.iter().filter(|m| app.discovered_motions.contains(m)).count();
+        let discovered =
+            motions.iter().filter(|m| app.player.discovered_motions.contains(m)).count();
         let bar_width = 8;
         let filled = if total == 0 {
             0
@@ -644,10 +659,10 @@ fn render_lost(ctx: &mut BTerm, app: &App) {
     }
     y += 1;
 
-    let duration = format_duration(app.final_time.unwrap_or(app.elapsed));
+    let duration = format_duration(app.session.final_time.unwrap_or(app.session.elapsed));
     let stats = format!(
         "  Level: {} / {}    Time: {}    Moves: {}",
-        app.level, TOTAL_LEVELS, duration, app.motion_count
+        app.player.level, TOTAL_LEVELS, duration, app.player.motion_count
     );
     ctx.print_color(center_x(stats.len()), y, white, black, &stats);
     y += 2;
@@ -705,7 +720,7 @@ fn render_pause_overlay(ctx: &mut BTerm, app: &App) {
     ];
 
     for (index, (option, label)) in options.iter().enumerate() {
-        let selected = app.pause_selection == *option;
+        let selected = app.session.pause_selection == *option;
         let prefix = if selected { "► " } else { "  " };
         let line = format!("{prefix}{label}");
         let color = if selected { yellow } else { dark_gray };

--- a/src/types.rs
+++ b/src/types.rs
@@ -364,32 +364,104 @@ impl Default for CheatBuffer {
     }
 }
 
-pub struct App {
+pub struct World {
     pub map: Map,
     pub visibility: VisibilityMap,
-    pub player: Player,
-    pub player_animation: Option<AnimationState>,
-    pub enemy_animations: Vec<(usize, AnimationState)>,
-    pub attack_effects: Vec<AttackEffect>,
-    pub pending_respawn: Option<Position>,
-    pub input_queue: Vec<(VirtualKeyCode, bool)>,
     pub enemies: Vec<Enemy>,
+    pub activated_torchlights: HashSet<Position>,
+}
+
+impl World {
+    pub fn new(map: Map) -> Self {
+        let visibility = VisibilityMap::new(map.width, map.height);
+        Self { map, visibility, enemies: Vec::new(), activated_torchlights: HashSet::new() }
+    }
+}
+
+pub struct PlayerState {
+    pub inner: Player,
     pub hp: i32,
+    pub trail: VecDeque<Position>,
+    pub motion_count: usize,
+    pub discovered_motions: HashSet<VimMotion>,
+    pub level: usize,
+    pub last_checkpoint: Option<Position>,
+    pub pending_respawn: Option<Position>,
+}
+
+impl PlayerState {
+    pub fn new(position: Position) -> Self {
+        Self {
+            inner: Player::new(position),
+            hp: MAX_HP,
+            trail: VecDeque::new(),
+            motion_count: 0,
+            discovered_motions: HashSet::new(),
+            level: 1,
+            last_checkpoint: None,
+            pending_respawn: None,
+        }
+    }
+}
+
+pub struct InputState {
+    pub input_queue: Vec<(VirtualKeyCode, bool)>,
+    pub pending_input: Option<PendingInput>,
+}
+
+impl InputState {
+    pub fn new() -> Self {
+        Self { input_queue: Vec::new(), pending_input: None }
+    }
+}
+
+impl Default for InputState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct Session {
     pub game_state: GameState,
     pub pause_selection: PauseOption,
     pub started: bool,
-    pub pending_input: Option<PendingInput>,
+    pub status_message: String,
     pub start_time: Instant,
     pub elapsed: Duration,
     pub final_time: Option<Duration>,
-    pub motion_count: usize,
-    pub status_message: String,
-    pub discovered_motions: HashSet<VimMotion>,
-    pub trail: VecDeque<Position>,
-    pub level: usize,
+}
+
+impl Session {
+    pub fn new() -> Self {
+        Self {
+            game_state: GameState::Playing,
+            pause_selection: PauseOption::Resume,
+            started: false,
+            status_message: String::from(
+                "Explore the dungeon and practice the highlighted motions.",
+            ),
+            start_time: Instant::now(),
+            elapsed: Duration::default(),
+            final_time: None,
+        }
+    }
+}
+
+impl Default for Session {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct App {
+    pub world: World,
+    pub player: PlayerState,
+    pub input: InputState,
+    pub session: Session,
+    pub player_animation: Option<AnimationState>,
+    pub enemy_animations: Vec<(usize, AnimationState)>,
+    pub attack_effects: Vec<AttackEffect>,
     pub audio: AudioManager,
-    pub last_checkpoint: Option<Position>,
-    pub activated_torchlights: HashSet<Position>,
     #[cfg(debug_assertions)]
     pub cheat_buf: CheatBuffer,
     #[cfg(debug_assertions)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -411,6 +411,30 @@ impl World {
             })
             .collect();
     }
+
+    pub fn update_visibility(&mut self, player_pos: Position) {
+        if self.visibility.width() != self.map.width || self.visibility.height() != self.map.height
+        {
+            self.visibility = VisibilityMap::new(self.map.width, self.map.height);
+        }
+        self.visibility.demote_visible_to_explored();
+        self.visibility.compute_fov(player_pos, FOV_RADIUS, |pos| {
+            matches!(
+                self.map.get_tile(pos.x, pos.y),
+                Tile::Floor | Tile::Exit | Tile::Obstacle | Tile::Torchlight
+            )
+        });
+        let sources: Vec<(Position, i32)> =
+            self.activated_torchlights.iter().map(|&pos| (pos, TORCHLIGHT_FOV_RADIUS)).collect();
+        if !sources.is_empty() {
+            self.visibility.compute_multi_fov(&sources, |pos| {
+                matches!(
+                    self.map.get_tile(pos.x, pos.y),
+                    Tile::Floor | Tile::Exit | Tile::Obstacle | Tile::Torchlight
+                )
+            });
+        }
+    }
 }
 
 pub struct PlayerState {

--- a/src/types.rs
+++ b/src/types.rs
@@ -376,6 +376,41 @@ impl World {
         let visibility = VisibilityMap::new(map.width, map.height);
         Self { map, visibility, enemies: Vec::new(), activated_torchlights: HashSet::new() }
     }
+
+    pub fn reset_for_level(&mut self, level: usize) {
+        self.map = Map::level(level);
+        if self.visibility.width() != self.map.width || self.visibility.height() != self.map.height
+        {
+            self.visibility = VisibilityMap::new(self.map.width, self.map.height);
+        }
+        self.visibility.reset();
+        self.enemies.clear();
+        self.activated_torchlights.clear();
+    }
+
+    pub fn spawn_enemies(&mut self, level: usize) {
+        self.enemies = self
+            .map
+            .enemy_spawns
+            .iter()
+            .enumerate()
+            .map(|(i, &pos)| {
+                let patrol_area = self
+                    .map
+                    .enemy_patrol_areas
+                    .get(i)
+                    .copied()
+                    .unwrap_or_else(|| PatrolArea::point(pos.x, pos.y));
+                if level == 4 {
+                    Enemy { position: pos, glyph: 'e', hp: Some(30), stunned_turns: 0, patrol_area }
+                } else {
+                    let mut e = Enemy::new(pos);
+                    e.patrol_area = patrol_area;
+                    e
+                }
+            })
+            .collect();
+    }
 }
 
 pub struct PlayerState {
@@ -402,6 +437,22 @@ impl PlayerState {
             pending_respawn: None,
         }
     }
+
+    pub fn advance_level(&mut self, level: usize, start: Position) {
+        self.level = level;
+        self.inner.position = start;
+        self.trail.clear();
+        self.last_checkpoint = None;
+        self.pending_respawn = None;
+    }
+
+    pub fn retry_level(&mut self, start: Position) {
+        self.inner.position = start;
+        self.hp = MAX_HP;
+        self.trail.clear();
+        self.last_checkpoint = None;
+        self.pending_respawn = None;
+    }
 }
 
 pub struct InputState {
@@ -412,6 +463,11 @@ pub struct InputState {
 impl InputState {
     pub fn new() -> Self {
         Self { input_queue: Vec::new(), pending_input: None }
+    }
+
+    pub fn clear(&mut self) {
+        self.input_queue.clear();
+        self.pending_input = None;
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -477,6 +477,23 @@ impl PlayerState {
         self.last_checkpoint = None;
         self.pending_respawn = None;
     }
+
+    pub fn motion_feedback(&self, motion: VimMotion, target: Option<char>) -> String {
+        match motion {
+            VimMotion::DeleteLine => String::from("dd clears the nearest obstacle on your row."),
+            VimMotion::Find => target
+                .map(|ch| format!("f{ch} searches forward for the next matching tile."))
+                .unwrap_or_else(|| String::from("Find motion ready.")),
+            VimMotion::Till => target
+                .map(|ch| format!("t{ch} stops one tile before the next match."))
+                .unwrap_or_else(|| String::from("Till motion ready.")),
+            _ => format!("{} — {}", motion.key_label(), motion.description()),
+        }
+    }
+
+    pub fn damage_feedback(&self) -> String {
+        format!("Hit! {} HP remaining.", self.hp)
+    }
 }
 
 pub struct InputState {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,11 +1,8 @@
-use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 use vim_rogue::animation::{AnimationState, AnimationTimer, GameClock, TestClock};
 use vim_rogue::audio::AudioManager;
 use vim_rogue::map::Map;
-use vim_rogue::player::Player;
 use vim_rogue::types::*;
-use vim_rogue::visibility::VisibilityMap;
 
 #[cfg(debug_assertions)]
 use vim_rogue::types::CheatBuffer;
@@ -24,75 +21,47 @@ pub fn test_map(width: usize, height: usize) -> Map {
 }
 
 pub fn started_app_with_map(map: Map, position: Position) -> App {
-    let visibility = VisibilityMap::new(map.width, map.height);
+    let world = World::new(map);
     let mut app = App {
-        map,
-        visibility,
-        player: Player::new(position),
+        world,
+        player: PlayerState::new(position),
+        input: InputState::new(),
+        session: Session::new(),
         player_animation: None,
         enemy_animations: Vec::new(),
         attack_effects: Vec::new(),
-        pending_respawn: None,
-        input_queue: Vec::new(),
-        enemies: Vec::new(),
-        hp: MAX_HP,
-        game_state: GameState::Playing,
-        pause_selection: PauseOption::Resume,
-        started: true,
-        pending_input: None,
-        start_time: Instant::now(),
-        elapsed: Duration::default(),
-        final_time: None,
-        motion_count: 0,
-        status_message: String::new(),
-        discovered_motions: Default::default(),
-        trail: VecDeque::new(),
-        level: 1,
         audio: AudioManager::new(),
-        last_checkpoint: None,
-        activated_torchlights: Default::default(),
         #[cfg(debug_assertions)]
         cheat_buf: CheatBuffer::new(),
         #[cfg(debug_assertions)]
         cheat_god_mode: false,
     };
+    app.session.started = true;
     app.update_visibility();
     app
 }
 
 pub fn test_app() -> App {
     let map = Map::new();
-    App {
-        player: Player::new(map.start),
-        visibility: VisibilityMap::new(map.width, map.height),
-        map,
+    let start = map.start;
+    let world = World::new(map);
+    let mut app = App {
+        world,
+        player: PlayerState::new(start),
+        input: InputState::new(),
+        session: Session::new(),
         player_animation: None,
         enemy_animations: Vec::new(),
         attack_effects: Vec::new(),
-        pending_respawn: None,
-        input_queue: Vec::new(),
-        enemies: Vec::new(),
-        hp: MAX_HP,
-        game_state: GameState::Playing,
-        pause_selection: PauseOption::Resume,
-        started: true,
-        pending_input: None,
-        start_time: Instant::now(),
-        elapsed: Duration::default(),
-        final_time: None,
-        motion_count: 0,
-        status_message: String::new(),
-        discovered_motions: Default::default(),
-        trail: VecDeque::new(),
-        level: 1,
         audio: AudioManager::new(),
-        last_checkpoint: None,
-        activated_torchlights: Default::default(),
         #[cfg(debug_assertions)]
         cheat_buf: CheatBuffer::new(),
         #[cfg(debug_assertions)]
         cheat_god_mode: false,
-    }
+    };
+    app.session.started = true;
+    app.update_visibility();
+    app
 }
 
 pub fn approx_eq(a: f32, b: f32) -> bool {

--- a/tests/game.rs
+++ b/tests/game.rs
@@ -19,28 +19,28 @@ use vim_rogue::visibility::{VisibilityMap, VisibilityState};
 fn app_new_starts_playing() {
     let app = App::new();
 
-    assert_eq!(app.game_state, GameState::Playing);
+    assert_eq!(app.session.game_state, GameState::Playing);
 }
 
 #[test]
 fn app_new_not_started() {
     let app = App::new();
 
-    assert!(!app.started);
+    assert!(!app.session.started);
 }
 
 #[test]
 fn app_new_start_time_exists() {
     let app = App::new();
 
-    assert!(app.start_time <= Instant::now());
+    assert!(app.session.start_time <= Instant::now());
 }
 
 #[test]
 fn app_trail_starts_empty() {
     let app = App::new();
 
-    assert!(app.trail.is_empty());
+    assert!(app.player.trail.is_empty());
 }
 
 #[test]
@@ -63,31 +63,31 @@ fn app_unique_motions_starts_zero() {
 fn app_new_has_visibility_map() {
     let app = App::new();
 
-    assert_eq!(app.visibility.width(), 80);
-    assert_eq!(app.visibility.height(), 40);
-    assert_eq!(app.visibility.get(app.player.position), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.width(), 80);
+    assert_eq!(app.world.visibility.height(), 40);
+    assert_eq!(app.world.visibility.get(app.player.inner.position), VisibilityState::Visible);
 }
 
 #[test]
 fn update_visibility_makes_area_visible() {
     let mut app = App::new();
 
-    app.visibility.reset();
+    app.world.visibility.reset();
     app.update_visibility();
 
-    assert_eq!(app.visibility.get(app.player.position), VisibilityState::Visible);
-    assert_eq!(app.visibility.get(Position { x: 3, y: 2 }), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(app.player.inner.position), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(Position { x: 3, y: 2 }), VisibilityState::Visible);
 }
 
 #[test]
 fn update_visibility_walls_block() {
     let mut app = App::new();
 
-    app.visibility.reset();
+    app.world.visibility.reset();
     app.update_visibility();
 
-    assert_eq!(app.visibility.get(Position { x: 1, y: 2 }), VisibilityState::Visible);
-    assert_eq!(app.visibility.get(Position { x: 0, y: 2 }), VisibilityState::Hidden);
+    assert_eq!(app.world.visibility.get(Position { x: 1, y: 2 }), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(Position { x: 0, y: 2 }), VisibilityState::Hidden);
 }
 
 #[test]
@@ -102,8 +102,8 @@ fn update_visibility_crosses_zone_boundaries() {
     let app = started_app_with_map(map, Position { x: 9, y: 2 });
 
     assert_eq!(app.current_zone(), Zone::Zone1);
-    assert_eq!(app.map.zone_at(Position { x: 10, y: 2 }), Zone::Zone2);
-    assert_eq!(app.visibility.get(Position { x: 10, y: 2 }), VisibilityState::Visible);
+    assert_eq!(app.world.map.zone_at(Position { x: 10, y: 2 }), Zone::Zone2);
+    assert_eq!(app.world.visibility.get(Position { x: 10, y: 2 }), VisibilityState::Visible);
 }
 
 #[test]
@@ -114,8 +114,8 @@ fn update_visibility_treats_obstacles_as_transparent() {
 
     let app = started_app_with_map(map, Position { x: 1, y: 2 });
 
-    assert_eq!(app.visibility.get(Position { x: 2, y: 2 }), VisibilityState::Visible);
-    assert_eq!(app.visibility.get(Position { x: 3, y: 2 }), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(Position { x: 2, y: 2 }), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(Position { x: 3, y: 2 }), VisibilityState::Visible);
 }
 
 #[test]
@@ -124,29 +124,29 @@ fn app_handle_key_starts_game() {
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert!(app.started);
+    assert!(app.session.started);
 }
 
 #[test]
 fn app_esc_opens_pause_menu() {
     let mut app = App::new();
-    app.started = true;
+    app.session.started = true;
 
     handle_key(&mut app, VirtualKeyCode::Escape, false);
 
-    assert_eq!(app.game_state, GameState::Paused);
-    assert_eq!(app.pause_selection, PauseOption::Resume);
+    assert_eq!(app.session.game_state, GameState::Paused);
+    assert_eq!(app.session.pause_selection, PauseOption::Resume);
 }
 
 #[test]
 fn app_q_opens_pause_menu() {
     let mut app = App::new();
-    app.started = true;
+    app.session.started = true;
 
     handle_key(&mut app, VirtualKeyCode::Q, false);
 
-    assert_eq!(app.game_state, GameState::Paused);
-    assert_eq!(app.pause_selection, PauseOption::Resume);
+    assert_eq!(app.session.game_state, GameState::Paused);
+    assert_eq!(app.session.pause_selection, PauseOption::Resume);
 }
 
 #[test]
@@ -155,7 +155,7 @@ fn app_h_motion_moves_player() {
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert_eq!(app.player.position, Position { x: 1, y: 0 });
+    assert_eq!(app.player.inner.position, Position { x: 1, y: 0 });
 }
 
 #[test]
@@ -164,8 +164,8 @@ fn app_trail_records_successful_motion() {
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.trail.len(), 1);
-    assert_eq!(app.trail[0], Position { x: 2, y: 0 });
+    assert_eq!(app.player.trail.len(), 1);
+    assert_eq!(app.player.trail[0], Position { x: 2, y: 0 });
 }
 
 #[test]
@@ -174,7 +174,7 @@ fn app_trail_does_not_record_failed_motion() {
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert!(app.trail.is_empty());
+    assert!(app.player.trail.is_empty());
 }
 
 #[test]
@@ -217,8 +217,8 @@ fn input_queued_during_animation() {
     handle_key(&mut app, VirtualKeyCode::L, false);
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.player.position, Position { x: 2, y: 0 });
-    assert_eq!(app.input_queue, vec![(VirtualKeyCode::L, false)]);
+    assert_eq!(app.player.inner.position, Position { x: 2, y: 0 });
+    assert_eq!(app.input.input_queue, vec![(VirtualKeyCode::L, false)]);
 }
 
 #[test]
@@ -230,8 +230,8 @@ fn queued_input_executed_after_animation() {
     tick(&mut app, PLAYER_MOVE_MS);
 
     let animation = app.player_animation.expect("queued move should start a new animation");
-    assert_eq!(app.player.position, Position { x: 3, y: 0 });
-    assert!(app.input_queue.is_empty());
+    assert_eq!(app.player.inner.position, Position { x: 3, y: 0 });
+    assert!(app.input.input_queue.is_empty());
     assert_eq!((animation.start_x, animation.start_y), (2.0, 0.0));
     assert_eq!((animation.end_x, animation.end_y), (3.0, 0.0));
 }
@@ -245,10 +245,10 @@ fn queued_multi_key_motion_executes_without_stalling() {
     handle_key(&mut app, VirtualKeyCode::G, false);
     tick(&mut app, PLAYER_MOVE_MS);
 
-    assert_eq!(app.player.position, Position { x: 3, y: 0 });
-    assert_eq!(app.pending_input, None);
+    assert_eq!(app.player.inner.position, Position { x: 3, y: 0 });
+    assert_eq!(app.input.pending_input, None);
     assert!(app.player_animation.is_some());
-    assert!(app.input_queue.is_empty());
+    assert!(app.input.input_queue.is_empty());
 }
 
 #[test]
@@ -257,20 +257,20 @@ fn queued_find_preserves_pending_input_after_animation() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 1, y: 0 });
-    app.level = TOTAL_LEVELS;
+    app.player.level = TOTAL_LEVELS;
 
     handle_key(&mut app, VirtualKeyCode::L, false);
     handle_key(&mut app, VirtualKeyCode::F, false);
 
     tick(&mut app, PLAYER_MOVE_MS);
 
-    assert_eq!(app.pending_input, Some(PendingInput::Find));
-    assert!(app.input_queue.is_empty());
+    assert_eq!(app.input.pending_input, Some(PendingInput::Find));
+    assert!(app.input.input_queue.is_empty());
 
     handle_key(&mut app, VirtualKeyCode::Period, true);
 
-    assert_eq!(app.pending_input, None);
-    assert_eq!(app.player.position, Position { x: 4, y: 0 });
+    assert_eq!(app.input.pending_input, None);
+    assert_eq!(app.player.inner.position, Position { x: 4, y: 0 });
 }
 
 #[test]
@@ -284,12 +284,12 @@ fn queued_till_preserves_pending_input_after_animation() {
 
     tick(&mut app, PLAYER_MOVE_MS);
 
-    assert_eq!(app.pending_input, Some(PendingInput::Till));
+    assert_eq!(app.input.pending_input, Some(PendingInput::Till));
 
     handle_key(&mut app, VirtualKeyCode::Period, true);
 
-    assert_eq!(app.pending_input, None);
-    assert_eq!(app.player.position, Position { x: 4, y: 0 });
+    assert_eq!(app.input.pending_input, None);
+    assert_eq!(app.player.inner.position, Position { x: 4, y: 0 });
 }
 
 #[test]
@@ -303,12 +303,12 @@ fn queued_delete_preserves_pending_input_after_animation() {
 
     tick(&mut app, PLAYER_MOVE_MS);
 
-    assert_eq!(app.pending_input, Some(PendingInput::Delete));
+    assert_eq!(app.input.pending_input, Some(PendingInput::Delete));
 
     handle_key(&mut app, VirtualKeyCode::D, false);
 
-    assert_eq!(app.pending_input, None);
-    assert_eq!(app.map.get_tile(4, 0), Tile::Floor);
+    assert_eq!(app.input.pending_input, None);
+    assert_eq!(app.world.map.get_tile(4, 0), Tile::Floor);
 }
 
 #[test]
@@ -320,12 +320,12 @@ fn queued_goto_line_preserves_pending_input_after_animation() {
 
     tick(&mut app, PLAYER_MOVE_MS);
 
-    assert_eq!(app.pending_input, Some(PendingInput::GotoLine));
+    assert_eq!(app.input.pending_input, Some(PendingInput::GotoLine));
 
     handle_key(&mut app, VirtualKeyCode::G, false);
 
-    assert_eq!(app.pending_input, None);
-    assert_eq!(app.player.position.y, 0);
+    assert_eq!(app.input.pending_input, None);
+    assert_eq!(app.player.inner.position.y, 0);
 }
 
 #[test]
@@ -341,9 +341,9 @@ fn rapid_keypresses_preserve_order_without_double_triggering() {
     tick(&mut app, PLAYER_MOVE_MS);
     tick(&mut app, PLAYER_MOVE_MS);
 
-    assert_eq!(app.player.position, Position { x: 3, y: 0 });
-    assert_eq!(app.motion_count, 4);
-    assert!(app.input_queue.is_empty());
+    assert_eq!(app.player.inner.position, Position { x: 3, y: 0 });
+    assert_eq!(app.player.motion_count, 4);
+    assert!(app.input.input_queue.is_empty());
     assert!(app.player_animation.is_some());
 }
 
@@ -353,7 +353,7 @@ fn rapid_keypresses_can_queue_find_and_target_together() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 1, y: 0 });
-    app.level = TOTAL_LEVELS;
+    app.player.level = TOTAL_LEVELS;
 
     handle_key(&mut app, VirtualKeyCode::L, false);
     handle_key(&mut app, VirtualKeyCode::F, false);
@@ -361,9 +361,9 @@ fn rapid_keypresses_can_queue_find_and_target_together() {
 
     tick(&mut app, PLAYER_MOVE_MS);
 
-    assert_eq!(app.pending_input, None);
-    assert_eq!(app.player.position, Position { x: 4, y: 0 });
-    assert!(app.input_queue.is_empty());
+    assert_eq!(app.input.pending_input, None);
+    assert_eq!(app.player.inner.position, Position { x: 4, y: 0 });
+    assert!(app.input.input_queue.is_empty());
 }
 
 #[test]
@@ -384,7 +384,7 @@ fn app_trail_caps_at_max() {
         handle_key(&mut app, VirtualKeyCode::H, false);
     }
 
-    assert!(app.trail.len() <= vim_rogue::types::TRAIL_MAX);
+    assert!(app.player.trail.len() <= vim_rogue::types::TRAIL_MAX);
 }
 
 #[test]
@@ -396,8 +396,8 @@ fn app_d_then_d_deletes_obstacle() {
     handle_key(&mut app, VirtualKeyCode::D, false);
     handle_key(&mut app, VirtualKeyCode::D, false);
 
-    assert_eq!(app.map.get_tile(3, 0), Tile::Floor);
-    assert_eq!(app.pending_input, None);
+    assert_eq!(app.world.map.get_tile(3, 0), Tile::Floor);
+    assert_eq!(app.input.pending_input, None);
 }
 
 #[test]
@@ -407,8 +407,8 @@ fn app_d_then_other_cancels() {
     handle_key(&mut app, VirtualKeyCode::D, false);
     handle_key(&mut app, VirtualKeyCode::X, false);
 
-    assert_eq!(app.pending_input, None);
-    assert!(app.status_message.contains("cancelled"));
+    assert_eq!(app.input.pending_input, None);
+    assert!(app.session.status_message.contains("cancelled"));
 }
 
 #[test]
@@ -416,12 +416,12 @@ fn app_f_then_char_finds() {
     let mut map = test_map(6, 1);
     map.set_tile(4, 0, Tile::Exit);
     let mut app = started_app_with_map(map, Position { x: 1, y: 0 });
-    app.level = TOTAL_LEVELS;
+    app.player.level = TOTAL_LEVELS;
 
     handle_key(&mut app, VirtualKeyCode::F, false);
     handle_key(&mut app, VirtualKeyCode::Period, true);
 
-    assert_eq!(app.player.position, Position { x: 4, y: 0 });
+    assert_eq!(app.player.inner.position, Position { x: 4, y: 0 });
 }
 
 #[test]
@@ -430,11 +430,11 @@ fn app_win_condition_on_exit_tile() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = TOTAL_LEVELS;
+    app.player.level = TOTAL_LEVELS;
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.game_state, GameState::Won);
+    assert_eq!(app.session.game_state, GameState::Won);
 }
 
 #[test]
@@ -443,13 +443,13 @@ fn app_motion_count_increments() {
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.motion_count, 1);
+    assert_eq!(app.player.motion_count, 1);
 }
 
 #[test]
 fn app_new_level_is_one() {
     let app = App::new();
-    assert_eq!(app.level, 1);
+    assert_eq!(app.player.level, 1);
 }
 
 #[test]
@@ -458,12 +458,12 @@ fn app_exit_on_level_1_transitions_to_level_2() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = 1;
+    app.player.level = 1;
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.level, 2);
-    assert_eq!(app.game_state, GameState::Playing);
+    assert_eq!(app.player.level, 2);
+    assert_eq!(app.session.game_state, GameState::Playing);
 }
 
 #[test]
@@ -472,12 +472,12 @@ fn app_exit_on_level_2_transitions_to_level_3() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = 2;
+    app.player.level = 2;
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.level, 3);
-    assert_eq!(app.game_state, GameState::Playing);
+    assert_eq!(app.player.level, 3);
+    assert_eq!(app.session.game_state, GameState::Playing);
 }
 
 #[test]
@@ -486,16 +486,16 @@ fn app_level_transition_preserves_stats() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = 1;
-    app.motion_count = 42;
-    app.discovered_motions.insert(VimMotion::H);
-    app.discovered_motions.insert(VimMotion::J);
+    app.player.level = 1;
+    app.player.motion_count = 42;
+    app.player.discovered_motions.insert(VimMotion::H);
+    app.player.discovered_motions.insert(VimMotion::J);
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.level, 2);
-    assert_eq!(app.motion_count, 43);
-    assert_eq!(app.discovered_motions.len(), 3);
+    assert_eq!(app.player.level, 2);
+    assert_eq!(app.player.motion_count, 43);
+    assert_eq!(app.player.discovered_motions.len(), 3);
 }
 
 #[test]
@@ -504,13 +504,13 @@ fn app_level_transition_clears_trail() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = 1;
-    app.trail.push_front(Position { x: 2, y: 0 });
+    app.player.level = 1;
+    app.player.trail.push_front(Position { x: 2, y: 0 });
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.level, 2);
-    assert!(app.trail.is_empty());
+    assert_eq!(app.player.level, 2);
+    assert!(app.player.trail.is_empty());
 }
 
 #[test]
@@ -519,13 +519,13 @@ fn app_level_transition_clears_pending_input() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = 1;
-    app.pending_input = Some(PendingInput::Delete);
+    app.player.level = 1;
+    app.input.pending_input = Some(PendingInput::Delete);
 
     app.advance_level();
 
-    assert_eq!(app.level, 2);
-    assert_eq!(app.pending_input, None);
+    assert_eq!(app.player.level, 2);
+    assert_eq!(app.input.pending_input, None);
 }
 
 #[test]
@@ -534,11 +534,11 @@ fn app_level_transition_resets_player_position() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = 1;
+    app.player.level = 1;
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.player.position, app.map.start);
+    assert_eq!(app.player.inner.position, app.world.map.start);
 }
 
 #[test]
@@ -547,12 +547,12 @@ fn app_level_transition_loads_new_map() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = 1;
+    app.player.level = 1;
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.level, 2);
-    assert_eq!(app.player.position, app.map.start);
+    assert_eq!(app.player.level, 2);
+    assert_eq!(app.player.inner.position, app.world.map.start);
 }
 
 #[test]
@@ -561,8 +561,8 @@ fn app_g_jump_to_column_bottom() {
 
     handle_key(&mut app, VirtualKeyCode::G, true);
 
-    assert_eq!(app.player.position, Position { x: 2, y: 4 });
-    assert_eq!(app.pending_input, None);
+    assert_eq!(app.player.inner.position, Position { x: 2, y: 4 });
+    assert_eq!(app.input.pending_input, None);
 }
 
 #[test]
@@ -570,12 +570,12 @@ fn app_gg_two_keys_jump_to_column_top() {
     let mut app = started_app_with_map(test_map(5, 5), Position { x: 2, y: 4 });
 
     handle_key(&mut app, VirtualKeyCode::G, false);
-    assert_eq!(app.pending_input, Some(PendingInput::GotoLine));
+    assert_eq!(app.input.pending_input, Some(PendingInput::GotoLine));
 
     handle_key(&mut app, VirtualKeyCode::G, false);
 
-    assert_eq!(app.player.position, Position { x: 2, y: 0 });
-    assert_eq!(app.pending_input, None);
+    assert_eq!(app.player.inner.position, Position { x: 2, y: 0 });
+    assert_eq!(app.input.pending_input, None);
 }
 
 #[test]
@@ -585,72 +585,72 @@ fn app_g_then_other_cancels() {
     handle_key(&mut app, VirtualKeyCode::G, false);
     handle_key(&mut app, VirtualKeyCode::X, false);
 
-    assert_eq!(app.player.position, Position { x: 2, y: 2 });
-    assert_eq!(app.pending_input, None);
-    assert!(app.status_message.contains("cancelled"));
+    assert_eq!(app.player.inner.position, Position { x: 2, y: 2 });
+    assert_eq!(app.input.pending_input, None);
+    assert!(app.session.status_message.contains("cancelled"));
 }
 
 #[test]
 fn app_lost_state_any_key_restarts_level() {
     let mut app = started_app_with_map(test_map(5, 5), Position { x: 3, y: 3 });
-    app.level = 2;
-    app.game_state = GameState::Lost;
-    app.trail.push_front(Position { x: 2, y: 2 });
+    app.player.level = 2;
+    app.session.game_state = GameState::Lost;
+    app.player.trail.push_front(Position { x: 2, y: 2 });
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert_eq!(app.game_state, GameState::Playing);
-    assert_eq!(app.player.position, app.map.start);
-    assert!(app.trail.is_empty());
-    assert_eq!(app.level, 2);
+    assert_eq!(app.session.game_state, GameState::Playing);
+    assert_eq!(app.player.inner.position, app.world.map.start);
+    assert!(app.player.trail.is_empty());
+    assert_eq!(app.player.level, 2);
 }
 
 #[test]
 fn advance_level_resets_visibility() {
     let mut app = started_app_with_map(test_map(5, 5), Position { x: 3, y: 3 });
     let far_tile = Position { x: 79, y: 0 };
-    app.level = 1;
-    app.visibility.set(far_tile, VisibilityState::Explored);
+    app.player.level = 1;
+    app.world.visibility.set(far_tile, VisibilityState::Explored);
 
     app.advance_level();
 
-    assert_eq!(app.visibility.get(far_tile), VisibilityState::Hidden);
-    assert_eq!(app.visibility.get(app.player.position), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(far_tile), VisibilityState::Hidden);
+    assert_eq!(app.world.visibility.get(app.player.inner.position), VisibilityState::Visible);
 }
 
 #[test]
 fn retry_level_resets_visibility() {
     let mut app = started_app_with_map(test_map(5, 5), Position { x: 3, y: 3 });
     let far_tile = Position { x: 79, y: 0 };
-    app.level = 2;
-    app.visibility.set(far_tile, VisibilityState::Explored);
+    app.player.level = 2;
+    app.world.visibility.set(far_tile, VisibilityState::Explored);
 
     app.retry_level();
 
-    assert_eq!(app.visibility.get(far_tile), VisibilityState::Hidden);
-    assert_eq!(app.visibility.get(app.player.position), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(far_tile), VisibilityState::Hidden);
+    assert_eq!(app.world.visibility.get(app.player.inner.position), VisibilityState::Visible);
 }
 
 #[test]
 fn app_enemy_collision_decrements_hp_and_removes_enemy() {
     let map = test_map(5, 5);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = MAX_HP;
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.player.hp = MAX_HP;
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert_eq!(app.hp, 20);
-    assert_eq!(app.game_state, GameState::Playing);
-    assert!(app.status_message.contains("20 HP remaining"));
-    assert!(app.enemies.is_empty());
+    assert_eq!(app.player.hp, 20);
+    assert_eq!(app.session.game_state, GameState::Playing);
+    assert!(app.session.status_message.contains("20 HP remaining"));
+    assert!(app.world.enemies.is_empty());
 }
 
 #[test]
 fn enemy_animation_starts_on_move() {
     let map = test_map(6, 3);
     let mut app = started_app_with_map(map, Position { x: 3, y: 1 });
-    app.enemies.push(Enemy::new(Position { x: 1, y: 1 }));
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 1 }));
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
@@ -665,7 +665,7 @@ fn enemy_animation_starts_on_move() {
 fn enemy_animation_completes_after_duration() {
     let map = test_map(6, 3);
     let mut app = started_app_with_map(map, Position { x: 3, y: 1 });
-    app.enemies.push(Enemy::new(Position { x: 1, y: 1 }));
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 1 }));
 
     handle_key(&mut app, VirtualKeyCode::L, false);
     tick(&mut app, ENEMY_MOVE_MS);
@@ -677,9 +677,9 @@ fn enemy_animation_completes_after_duration() {
 fn multiple_enemies_animate_simultaneously() {
     let map = test_map(8, 5);
     let mut app = started_app_with_map(map, Position { x: 4, y: 2 });
-    app.enemies.push(Enemy::new(Position { x: 0, y: 0 }));
-    app.enemies.push(Enemy::new(Position { x: 0, y: 2 }));
-    app.enemies.push(Enemy::new(Position { x: 0, y: 4 }));
+    app.world.enemies.push(Enemy::new(Position { x: 0, y: 0 }));
+    app.world.enemies.push(Enemy::new(Position { x: 0, y: 2 }));
+    app.world.enemies.push(Enemy::new(Position { x: 0, y: 4 }));
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
@@ -693,7 +693,7 @@ fn multiple_enemies_animate_simultaneously() {
 fn enemy_animation_interpolates_position() {
     let map = test_map(6, 3);
     let mut app = started_app_with_map(map, Position { x: 3, y: 1 });
-    app.enemies.push(Enemy::new(Position { x: 1, y: 1 }));
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 1 }));
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
@@ -708,18 +708,18 @@ fn enemy_animation_interpolates_position() {
 fn app_enemy_collision_sets_lost_when_hp_depleted() {
     let map = test_map(5, 5);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = 10;
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.player.hp = 10;
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert_eq!(app.hp, 0);
-    assert_eq!(app.game_state, GameState::Dying);
+    assert_eq!(app.player.hp, 0);
+    assert_eq!(app.session.game_state, GameState::Dying);
     assert!(!app.attack_effects.is_empty());
     tick(&mut app, ATTACK_EFFECT_MS); // ages effects to complete
     tick(&mut app, 0.0); // detects all expired → transitions to Lost
-    assert_eq!(app.game_state, GameState::Lost);
-    assert!(app.status_message.contains("Game over"));
+    assert_eq!(app.session.game_state, GameState::Lost);
+    assert!(app.session.status_message.contains("Game over"));
 }
 
 #[test]
@@ -728,14 +728,14 @@ fn app_advance_level_spawns_enemies_from_map() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = 2;
+    app.player.level = 2;
 
     app.advance_level();
 
-    assert_eq!(app.level, 3);
+    assert_eq!(app.player.level, 3);
     let level3_map = Map::level(3);
-    assert_eq!(app.enemies.len(), level3_map.enemy_spawns.len());
-    for (enemy, spawn) in app.enemies.iter().zip(level3_map.enemy_spawns.iter()) {
+    assert_eq!(app.world.enemies.len(), level3_map.enemy_spawns.len());
+    for (enemy, spawn) in app.world.enemies.iter().zip(level3_map.enemy_spawns.iter()) {
         assert_eq!(enemy.position, *spawn);
     }
 }
@@ -746,12 +746,12 @@ fn app_advance_level_preserves_hp() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = 1;
-    app.hp = 20;
+    app.player.level = 1;
+    app.player.hp = 20;
 
     app.advance_level();
 
-    assert_eq!(app.hp, 20);
+    assert_eq!(app.player.hp, 20);
 }
 
 #[test]
@@ -768,13 +768,13 @@ fn app_advance_level_level_2_to_3_spawns_enemies() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = 2;
+    app.player.level = 2;
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.level, 3);
-    assert!(!app.enemies.is_empty());
-    assert_eq!(app.enemies.len(), Map::level(3).enemy_spawns.len());
+    assert_eq!(app.player.level, 3);
+    assert!(!app.world.enemies.is_empty());
+    assert_eq!(app.world.enemies.len(), Map::level(3).enemy_spawns.len());
 }
 
 #[test]
@@ -783,12 +783,12 @@ fn app_advance_level_preserves_motion_count() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = 1;
-    app.motion_count = 42;
+    app.player.level = 1;
+    app.player.motion_count = 42;
 
     app.advance_level();
 
-    assert_eq!(app.motion_count, 42);
+    assert_eq!(app.player.motion_count, 42);
 }
 
 #[test]
@@ -798,7 +798,7 @@ fn audio_movement_plays_on_successful_move() {
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_ne!(app.player.position, Position { x: 2, y: 0 });
+    assert_ne!(app.player.inner.position, Position { x: 2, y: 0 });
 }
 
 #[test]
@@ -808,7 +808,7 @@ fn audio_no_sound_on_failed_move() {
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert_eq!(app.player.position, Position { x: 0, y: 0 });
+    assert_eq!(app.player.inner.position, Position { x: 0, y: 0 });
 }
 
 #[test]
@@ -825,7 +825,7 @@ fn audio_zone_entry_plays_on_zone_change() {
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.player.position, Position { x: 16, y: 0 });
+    assert_eq!(app.player.inner.position, Position { x: 16, y: 0 });
 }
 
 #[test]
@@ -835,21 +835,24 @@ fn audio_no_zone_entry_sound_when_same_zone() {
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.map.zone_at(app.player.position), app.map.zone_at(Position { x: 2, y: 0 }));
+    assert_eq!(
+        app.world.map.zone_at(app.player.inner.position),
+        app.world.map.zone_at(Position { x: 2, y: 0 })
+    );
 }
 
 #[test]
 fn audio_damage_plays_on_enemy_hit() {
     let map = test_map(5, 5);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = MAX_HP;
+    app.player.hp = MAX_HP;
     app.audio.enable();
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert_eq!(app.hp, 20);
-    assert!(app.enemies.is_empty());
+    assert_eq!(app.player.hp, 20);
+    assert!(app.world.enemies.is_empty());
 }
 
 #[test]
@@ -858,12 +861,12 @@ fn audio_victory_plays_on_win() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = TOTAL_LEVELS;
+    app.player.level = TOTAL_LEVELS;
     app.audio.enable();
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.game_state, GameState::Won);
+    assert_eq!(app.session.game_state, GameState::Won);
 }
 
 #[test]
@@ -872,13 +875,13 @@ fn audio_level_complete_plays_on_advance() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = 1;
+    app.player.level = 1;
     app.audio.enable();
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.level, 2);
-    assert_eq!(app.game_state, GameState::Playing);
+    assert_eq!(app.player.level, 2);
+    assert_eq!(app.session.game_state, GameState::Playing);
 }
 
 #[test]
@@ -886,11 +889,11 @@ fn audio_enemy_step_plays_when_enemies_move() {
     let map = test_map(5, 5);
     let mut app = started_app_with_map(map, Position { x: 4, y: 0 });
     app.audio.enable();
-    app.enemies.push(Enemy::new(Position { x: 2, y: 2 }));
+    app.world.enemies.push(Enemy::new(Position { x: 2, y: 2 }));
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert!(!app.enemies.is_empty());
+    assert!(!app.world.enemies.is_empty());
 }
 
 #[test]
@@ -907,16 +910,16 @@ fn audio_no_panic_when_disabled() {
     map2.set_tile(4, 0, Tile::Exit);
     map2.exit = Position { x: 4, y: 0 };
     let mut app2 = started_app_with_map(map2, Position { x: 3, y: 0 });
-    app2.level = TOTAL_LEVELS;
+    app2.player.level = TOTAL_LEVELS;
     handle_key(&mut app2, VirtualKeyCode::L, false);
-    assert_eq!(app2.game_state, GameState::Won);
+    assert_eq!(app2.session.game_state, GameState::Won);
 
     let map3 = test_map(5, 5);
     let mut app3 = started_app_with_map(map3, Position { x: 3, y: 0 });
-    app3.hp = MAX_HP;
-    app3.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app3.player.hp = MAX_HP;
+    app3.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
     handle_key(&mut app3, VirtualKeyCode::H, false);
-    assert_eq!(app3.hp, 20);
+    assert_eq!(app3.player.hp, 20);
 }
 
 #[test]
@@ -933,9 +936,9 @@ fn torchlight_activation_on_step() {
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert!(app.activated_torchlights.contains(&Position { x: 6, y: 5 }));
-    assert_eq!(app.last_checkpoint, Some(Position { x: 6, y: 5 }));
-    assert!(app.status_message.contains("Checkpoint"));
+    assert!(app.world.activated_torchlights.contains(&Position { x: 6, y: 5 }));
+    assert_eq!(app.player.last_checkpoint, Some(Position { x: 6, y: 5 }));
+    assert!(app.session.status_message.contains("Checkpoint"));
 }
 
 #[test]
@@ -946,12 +949,12 @@ fn torchlight_activation_idempotent() {
     let mut app = started_app_with_map(map, Position { x: 5, y: 5 });
 
     handle_key(&mut app, VirtualKeyCode::L, false);
-    assert!(app.activated_torchlights.contains(&Position { x: 6, y: 5 }));
+    assert!(app.world.activated_torchlights.contains(&Position { x: 6, y: 5 }));
 
     handle_key(&mut app, VirtualKeyCode::L, false);
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert_eq!(app.activated_torchlights.len(), 1);
+    assert_eq!(app.world.activated_torchlights.len(), 1);
 }
 
 #[test]
@@ -960,11 +963,11 @@ fn torchlight_reveals_nearby_tiles() {
     map.set_tile(20, 20, Tile::Torchlight);
     let mut app = started_app_with_map(map, Position { x: 5, y: 5 });
 
-    app.activated_torchlights.insert(Position { x: 20, y: 20 });
+    app.world.activated_torchlights.insert(Position { x: 20, y: 20 });
     app.update_visibility();
 
-    assert_eq!(app.visibility.get(Position { x: 20, y: 20 }), VisibilityState::Visible);
-    assert_eq!(app.visibility.get(Position { x: 22, y: 20 }), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(Position { x: 20, y: 20 }), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(Position { x: 22, y: 20 }), VisibilityState::Visible);
 }
 
 #[test]
@@ -974,11 +977,11 @@ fn torchlight_visibility_persists_after_player_moves_away() {
     let mut app = started_app_with_map(map, Position { x: 19, y: 20 });
 
     handle_key(&mut app, VirtualKeyCode::L, false);
-    assert!(app.activated_torchlights.contains(&Position { x: 20, y: 20 }));
+    assert!(app.world.activated_torchlights.contains(&Position { x: 20, y: 20 }));
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert_eq!(app.visibility.get(Position { x: 20, y: 20 }), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(Position { x: 20, y: 20 }), VisibilityState::Visible);
 }
 
 #[test]
@@ -987,28 +990,28 @@ fn advance_level_clears_torchlight_checkpoints() {
     map.set_tile(4, 0, Tile::Exit);
     map.exit = Position { x: 4, y: 0 };
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.level = 1;
-    app.activated_torchlights.insert(Position { x: 2, y: 2 });
-    app.last_checkpoint = Some(Position { x: 2, y: 2 });
+    app.player.level = 1;
+    app.world.activated_torchlights.insert(Position { x: 2, y: 2 });
+    app.player.last_checkpoint = Some(Position { x: 2, y: 2 });
 
     app.advance_level();
 
-    assert!(app.activated_torchlights.is_empty());
-    assert_eq!(app.last_checkpoint, None);
+    assert!(app.world.activated_torchlights.is_empty());
+    assert_eq!(app.player.last_checkpoint, None);
 }
 
 #[test]
 fn retry_level_clears_torchlight_checkpoints() {
     let mut map = test_map(5, 5);
     let mut app = started_app_with_map(map, Position { x: 3, y: 3 });
-    app.level = 2;
-    app.activated_torchlights.insert(Position { x: 2, y: 2 });
-    app.last_checkpoint = Some(Position { x: 2, y: 2 });
+    app.player.level = 2;
+    app.world.activated_torchlights.insert(Position { x: 2, y: 2 });
+    app.player.last_checkpoint = Some(Position { x: 2, y: 2 });
 
     app.retry_level();
 
-    assert!(app.activated_torchlights.is_empty());
-    assert_eq!(app.last_checkpoint, None);
+    assert!(app.world.activated_torchlights.is_empty());
+    assert_eq!(app.player.last_checkpoint, None);
 }
 
 #[test]
@@ -1018,8 +1021,8 @@ fn visibility_updates_after_each_move() {
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.visibility.get(Position { x: 6, y: 10 }), VisibilityState::Visible);
-    assert_eq!(app.visibility.get(app.player.position), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(Position { x: 6, y: 10 }), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(app.player.inner.position), VisibilityState::Visible);
 }
 
 #[test]
@@ -1031,63 +1034,63 @@ fn audio_enabled_does_not_crash_during_movement() {
     handle_key(&mut app, VirtualKeyCode::H, false);
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.player.position, Position { x: 3, y: 0 });
+    assert_eq!(app.player.inner.position, Position { x: 3, y: 0 });
 }
 
 fn level4_app_with_enemy(enemy_pos: Position, enemy_hp: Option<i32>) -> App {
     let map = test_map(20, 20);
     let mut app = started_app_with_map(map, Position { x: 5, y: 5 });
-    app.level = 4;
-    app.enemies = vec![Enemy { position: enemy_pos, hp: enemy_hp, ..Enemy::new(enemy_pos) }];
-    app.player.last_direction = Some(Direction::Right);
+    app.player.level = 4;
+    app.world.enemies = vec![Enemy { position: enemy_pos, hp: enemy_hp, ..Enemy::new(enemy_pos) }];
+    app.player.inner.last_direction = Some(Direction::Right);
     app
 }
 
 #[test]
 fn facing_updates_on_l_movement() {
     let mut app = started_app_with_map(test_map(5, 1), Position { x: 2, y: 0 });
-    assert_eq!(app.player.last_direction, None);
+    assert_eq!(app.player.inner.last_direction, None);
     handle_key(&mut app, VirtualKeyCode::L, false);
-    assert_eq!(app.player.last_direction, Some(Direction::Right));
+    assert_eq!(app.player.inner.last_direction, Some(Direction::Right));
 }
 
 #[test]
 fn facing_updates_on_h_movement() {
     let mut app = started_app_with_map(test_map(5, 1), Position { x: 2, y: 0 });
     handle_key(&mut app, VirtualKeyCode::H, false);
-    assert_eq!(app.player.last_direction, Some(Direction::Left));
+    assert_eq!(app.player.inner.last_direction, Some(Direction::Left));
 }
 
 #[test]
 fn facing_updates_on_j_movement() {
     let mut app = started_app_with_map(test_map(5, 5), Position { x: 2, y: 2 });
     handle_key(&mut app, VirtualKeyCode::J, false);
-    assert_eq!(app.player.last_direction, Some(Direction::Down));
+    assert_eq!(app.player.inner.last_direction, Some(Direction::Down));
 }
 
 #[test]
 fn facing_updates_on_k_movement() {
     let mut app = started_app_with_map(test_map(5, 5), Position { x: 2, y: 2 });
     handle_key(&mut app, VirtualKeyCode::K, false);
-    assert_eq!(app.player.last_direction, Some(Direction::Up));
+    assert_eq!(app.player.inner.last_direction, Some(Direction::Up));
 }
 
 #[test]
 fn facing_does_not_update_on_failed_move() {
     let mut app = started_app_with_map(test_map(5, 1), Position { x: 0, y: 0 });
-    assert_eq!(app.player.last_direction, None);
+    assert_eq!(app.player.inner.last_direction, None);
     handle_key(&mut app, VirtualKeyCode::H, false);
-    assert_eq!(app.player.last_direction, None);
+    assert_eq!(app.player.inner.last_direction, None);
 }
 
 #[test]
 fn melee_attack_hits_enemy_on_level_4() {
     let mut app = level4_app_with_enemy(Position { x: 6, y: 5 }, Some(30));
-    let initial_motions = app.motion_count;
+    let initial_motions = app.player.motion_count;
     handle_key(&mut app, VirtualKeyCode::X, false);
-    assert!(app.status_message.contains("Hit"));
-    assert!(app.status_message.contains("20"));
-    assert_eq!(app.motion_count, initial_motions + 1);
+    assert!(app.session.status_message.contains("Hit"));
+    assert!(app.session.status_message.contains("20"));
+    assert_eq!(app.player.motion_count, initial_motions + 1);
 }
 
 #[test]
@@ -1095,88 +1098,91 @@ fn melee_attack_kills_enemy_after_3_hits() {
     let mut app = level4_app_with_enemy(Position { x: 6, y: 5 }, Some(30));
 
     handle_key(&mut app, VirtualKeyCode::X, false);
-    assert!(app.status_message.contains("Hit"));
-    assert!(app.status_message.contains("20"));
+    assert!(app.session.status_message.contains("Hit"));
+    assert!(app.session.status_message.contains("20"));
 
-    app.enemies = vec![Enemy {
+    app.world.enemies = vec![Enemy {
         position: Position { x: 6, y: 5 },
         hp: Some(20),
         ..Enemy::new(Position { x: 6, y: 5 })
     }];
-    app.player.last_direction = Some(Direction::Right);
+    app.player.inner.last_direction = Some(Direction::Right);
 
     handle_key(&mut app, VirtualKeyCode::X, false);
-    assert!(app.status_message.contains("Hit"));
-    assert!(app.status_message.contains("10"));
+    assert!(app.session.status_message.contains("Hit"));
+    assert!(app.session.status_message.contains("10"));
 
-    app.enemies = vec![Enemy {
+    app.world.enemies = vec![Enemy {
         position: Position { x: 6, y: 5 },
         hp: Some(10),
         ..Enemy::new(Position { x: 6, y: 5 })
     }];
-    app.player.last_direction = Some(Direction::Right);
+    app.player.inner.last_direction = Some(Direction::Right);
 
     handle_key(&mut app, VirtualKeyCode::X, false);
-    assert!(app.status_message.contains("defeated"));
+    assert!(app.session.status_message.contains("defeated"));
 }
 
 #[test]
 fn melee_attack_noop_on_level_3_non_hp_enemy() {
     let mut app = level4_app_with_enemy(Position { x: 6, y: 5 }, None);
-    app.level = 3;
-    let initial_motions = app.motion_count;
+    app.player.level = 3;
+    let initial_motions = app.player.motion_count;
     handle_key(&mut app, VirtualKeyCode::X, false);
-    assert!(app.status_message.contains("Can't attack"));
-    assert_eq!(app.enemies[0].hp, None);
-    assert_eq!(app.motion_count, initial_motions);
+    assert!(app.session.status_message.contains("Can't attack"));
+    assert_eq!(app.world.enemies[0].hp, None);
+    assert_eq!(app.player.motion_count, initial_motions);
 }
 
 #[test]
 fn melee_attack_noop_on_level_1_non_hp_enemy() {
     let mut app = level4_app_with_enemy(Position { x: 6, y: 5 }, None);
-    app.level = 1;
+    app.player.level = 1;
     handle_key(&mut app, VirtualKeyCode::X, false);
-    assert!(app.status_message.contains("Can't attack"));
+    assert!(app.session.status_message.contains("Can't attack"));
 }
 
 #[test]
 fn melee_attack_no_facing() {
     let mut app = level4_app_with_enemy(Position { x: 6, y: 5 }, Some(30));
-    app.player.last_direction = None;
-    let initial_motions = app.motion_count;
+    app.player.inner.last_direction = None;
+    let initial_motions = app.player.motion_count;
     handle_key(&mut app, VirtualKeyCode::X, false);
-    assert!(app.status_message.contains("direction") || app.status_message.contains("move"));
-    assert_eq!(app.enemies[0].hp, Some(30));
-    assert_eq!(app.motion_count, initial_motions);
+    assert!(
+        app.session.status_message.contains("direction")
+            || app.session.status_message.contains("move")
+    );
+    assert_eq!(app.world.enemies[0].hp, Some(30));
+    assert_eq!(app.player.motion_count, initial_motions);
 }
 
 #[test]
 fn melee_attack_miss_no_enemy() {
     let mut app = level4_app_with_enemy(Position { x: 15, y: 5 }, Some(30));
-    let initial_motions = app.motion_count;
+    let initial_motions = app.player.motion_count;
     handle_key(&mut app, VirtualKeyCode::X, false);
-    assert!(app.status_message.contains("Nothing"));
-    assert_eq!(app.motion_count, initial_motions + 1);
-    assert_eq!(app.enemies.len(), 1);
+    assert!(app.session.status_message.contains("Nothing"));
+    assert_eq!(app.player.motion_count, initial_motions + 1);
+    assert_eq!(app.world.enemies.len(), 1);
 }
 
 #[test]
 fn melee_attack_cant_attack_hp_none_enemy() {
     let mut app = level4_app_with_enemy(Position { x: 6, y: 5 }, None);
-    let initial_motions = app.motion_count;
+    let initial_motions = app.player.motion_count;
     handle_key(&mut app, VirtualKeyCode::X, false);
-    assert!(app.status_message.contains("Can't attack"));
-    assert_eq!(app.enemies.len(), 1);
-    assert_eq!(app.motion_count, initial_motions);
+    assert!(app.session.status_message.contains("Can't attack"));
+    assert_eq!(app.world.enemies.len(), 1);
+    assert_eq!(app.player.motion_count, initial_motions);
 }
 
 #[test]
 fn melee_attack_stuns_enemy() {
     let mut app = level4_app_with_enemy(Position { x: 6, y: 5 }, Some(30));
     handle_key(&mut app, VirtualKeyCode::X, false);
-    assert_eq!(app.enemies[0].stunned_turns, 0);
-    assert_eq!(app.enemies[0].hp, Some(20));
-    assert!(app.status_message.contains("20"));
+    assert_eq!(app.world.enemies[0].stunned_turns, 0);
+    assert_eq!(app.world.enemies[0].hp, Some(20));
+    assert!(app.session.status_message.contains("20"));
 }
 
 #[test]
@@ -1184,55 +1190,63 @@ fn stunned_enemy_does_not_move() {
     let mut app = level4_app_with_enemy(Position { x: 6, y: 5 }, Some(30));
     handle_key(&mut app, VirtualKeyCode::X, false);
     // Enemy was at (6,5), got stunned, should not have moved during enemies_step
-    assert_eq!(app.enemies[0].position, Position { x: 6, y: 5 });
+    assert_eq!(app.world.enemies[0].position, Position { x: 6, y: 5 });
     // Stun decremented from 1 to 0 during enemies_step
-    assert_eq!(app.enemies[0].stunned_turns, 0);
+    assert_eq!(app.world.enemies[0].stunned_turns, 0);
 }
 
 #[test]
 fn stunned_enemy_does_not_deal_damage() {
     let map = test_map(20, 20);
     let mut app = started_app_with_map(map, Position { x: 5, y: 5 });
-    app.level = 4;
-    app.hp = 10;
+    app.player.level = 4;
+    app.player.hp = 10;
     // Enemy adjacent on the left — would step onto player if not stunned
-    app.enemies = vec![Enemy {
+    app.world.enemies = vec![Enemy {
         position: Position { x: 4, y: 5 },
         hp: Some(30),
         stunned_turns: 1,
         ..Enemy::new(Position { x: 4, y: 5 })
     }];
-    app.player.last_direction = Some(Direction::Right);
+    app.player.inner.last_direction = Some(Direction::Right);
 
     // Player moves right to (6,5) — enemies_step runs, stunned enemy stays put
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.hp, 10, "Stunned enemy should not deal damage");
-    assert_eq!(app.enemies[0].position, Position { x: 4, y: 5 }, "Stunned enemy should not move");
+    assert_eq!(app.player.hp, 10, "Stunned enemy should not deal damage");
+    assert_eq!(
+        app.world.enemies[0].position,
+        Position { x: 4, y: 5 },
+        "Stunned enemy should not move"
+    );
 }
 
 #[test]
 fn stun_wears_off_after_one_turn() {
     let map = test_map(20, 20);
     let mut app = started_app_with_map(map, Position { x: 5, y: 5 });
-    app.level = 4;
-    app.enemies = vec![Enemy {
+    app.player.level = 4;
+    app.world.enemies = vec![Enemy {
         position: Position { x: 6, y: 5 },
         hp: Some(30),
         stunned_turns: 1,
         ..Enemy::new(Position { x: 6, y: 5 })
     }];
-    app.player.last_direction = Some(Direction::Right);
+    app.player.inner.last_direction = Some(Direction::Right);
 
     // Turn 1: enemy is stunned, stun decrements to 0
     handle_key(&mut app, VirtualKeyCode::X, false);
-    assert_eq!(app.enemies[0].stunned_turns, 0);
-    assert_eq!(app.enemies[0].position, Position { x: 6, y: 5 }, "Still stunned, should not move");
+    assert_eq!(app.world.enemies[0].stunned_turns, 0);
+    assert_eq!(
+        app.world.enemies[0].position,
+        Position { x: 6, y: 5 },
+        "Still stunned, should not move"
+    );
 
     // Turn 2: stun has worn off, enemy should move toward player
     handle_key(&mut app, VirtualKeyCode::H, false);
     assert_eq!(
-        app.enemies[0].position,
+        app.world.enemies[0].position,
         Position { x: 5, y: 5 },
         "Enemy should move after stun wears off"
     );
@@ -1242,10 +1256,10 @@ fn stun_wears_off_after_one_turn() {
 fn stun_prevents_enemy_counterattack_after_melee() {
     let map = test_map(20, 20);
     let mut app = started_app_with_map(map, Position { x: 5, y: 5 });
-    app.level = 4;
-    app.hp = 10;
-    app.player.last_direction = Some(Direction::Right);
-    app.enemies = vec![Enemy {
+    app.player.level = 4;
+    app.player.hp = 10;
+    app.player.inner.last_direction = Some(Direction::Right);
+    app.world.enemies = vec![Enemy {
         position: Position { x: 6, y: 5 },
         hp: Some(20),
         ..Enemy::new(Position { x: 6, y: 5 })
@@ -1254,87 +1268,98 @@ fn stun_prevents_enemy_counterattack_after_melee() {
     // Melee hits enemy (20->10), enemy gets stunned, doesn't step onto player
     handle_key(&mut app, VirtualKeyCode::X, false);
 
-    assert_eq!(app.hp, 10, "Player should not take damage from stunned enemy");
-    assert_eq!(app.enemies.len(), 1);
-    assert_eq!(app.enemies[0].hp, Some(10));
-    assert_eq!(app.enemies[0].position, Position { x: 6, y: 5 }, "Stunned enemy should not move");
-    assert_eq!(app.enemies[0].stunned_turns, 0, "Stun should have decremented during enemies_step");
+    assert_eq!(app.player.hp, 10, "Player should not take damage from stunned enemy");
+    assert_eq!(app.world.enemies.len(), 1);
+    assert_eq!(app.world.enemies[0].hp, Some(10));
+    assert_eq!(
+        app.world.enemies[0].position,
+        Position { x: 6, y: 5 },
+        "Stunned enemy should not move"
+    );
+    assert_eq!(
+        app.world.enemies[0].stunned_turns, 0,
+        "Stun should have decremented during enemies_step"
+    );
 }
 
 #[test]
 fn death_with_checkpoint_respawns_at_torchlight() {
     let map = test_map(20, 20);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = 10;
-    app.last_checkpoint = Some(Position { x: 10, y: 10 });
-    app.activated_torchlights.insert(Position { x: 10, y: 10 });
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.player.hp = 10;
+    app.player.last_checkpoint = Some(Position { x: 10, y: 10 });
+    app.world.activated_torchlights.insert(Position { x: 10, y: 10 });
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert_eq!(app.game_state, GameState::Dying);
+    assert_eq!(app.session.game_state, GameState::Dying);
     tick(&mut app, ATTACK_EFFECT_MS);
     tick(&mut app, 0.0);
-    assert_eq!(app.hp, MAX_HP, "HP should be restored to MAX_HP after checkpoint respawn");
+    assert_eq!(app.player.hp, MAX_HP, "HP should be restored to MAX_HP after checkpoint respawn");
     assert_eq!(
-        app.player.position,
+        app.player.inner.position,
         Position { x: 10, y: 10 },
         "Player should respawn at checkpoint"
     );
     assert_eq!(
-        app.game_state,
+        app.session.game_state,
         GameState::Playing,
         "Game state should remain Playing after respawn"
     );
-    assert!(app.status_message.contains("Respawned at checkpoint"));
+    assert!(app.session.status_message.contains("Respawned at checkpoint"));
 }
 
 #[test]
 fn death_without_checkpoint_triggers_lost() {
     let map = test_map(20, 20);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = 10;
-    app.last_checkpoint = None;
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.player.hp = 10;
+    app.player.last_checkpoint = None;
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert_eq!(app.hp, 0);
-    assert_eq!(app.game_state, GameState::Dying, "Should be Dying when no checkpoint");
+    assert_eq!(app.player.hp, 0);
+    assert_eq!(app.session.game_state, GameState::Dying, "Should be Dying when no checkpoint");
     tick(&mut app, ATTACK_EFFECT_MS); // ages effects to complete
     tick(&mut app, 0.0); // detects all expired → transitions to Lost
-    assert_eq!(app.game_state, GameState::Lost);
-    assert!(app.status_message.contains("Game over"));
+    assert_eq!(app.session.game_state, GameState::Lost);
+    assert!(app.session.status_message.contains("Game over"));
 }
 
 #[test]
 fn checkpoint_state_persists_after_respawn() {
     let map = test_map(20, 20);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = 10;
+    app.player.hp = 10;
     let checkpoint = Position { x: 10, y: 10 };
-    app.last_checkpoint = Some(checkpoint);
-    app.activated_torchlights.insert(checkpoint);
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.player.last_checkpoint = Some(checkpoint);
+    app.world.activated_torchlights.insert(checkpoint);
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
     assert!(
-        app.activated_torchlights.contains(&checkpoint),
+        app.world.activated_torchlights.contains(&checkpoint),
         "Torchlights should persist after respawn"
     );
-    assert_eq!(app.last_checkpoint, Some(checkpoint), "Checkpoint should persist after respawn");
+    assert_eq!(
+        app.player.last_checkpoint,
+        Some(checkpoint),
+        "Checkpoint should persist after respawn"
+    );
 }
 
 #[test]
 fn surviving_enemies_persist_after_checkpoint_respawn() {
     let map = test_map(20, 20);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = 10;
-    app.last_checkpoint = Some(Position { x: 10, y: 10 });
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.player.hp = 10;
+    app.player.last_checkpoint = Some(Position { x: 10, y: 10 });
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
     let far_enemy_pos = Position { x: 15, y: 15 };
-    app.enemies.push(Enemy {
+    app.world.enemies.push(Enemy {
         position: far_enemy_pos,
         hp: Some(30),
         patrol_area: PatrolArea { min_x: 10, min_y: 10, max_x: 19, max_y: 19 },
@@ -1342,59 +1367,65 @@ fn surviving_enemies_persist_after_checkpoint_respawn() {
     });
 
     handle_key(&mut app, VirtualKeyCode::H, false);
-    assert_eq!(app.game_state, GameState::Dying);
+    assert_eq!(app.session.game_state, GameState::Dying);
     tick(&mut app, ATTACK_EFFECT_MS);
     tick(&mut app, 0.0);
-    assert_eq!(app.game_state, GameState::Playing);
-    assert_eq!(app.enemies.len(), 1, "Non-colliding enemy should survive checkpoint respawn");
-    assert_ne!(app.enemies[0].position, far_enemy_pos, "Surviving enemy should have moved via BFS");
+    assert_eq!(app.session.game_state, GameState::Playing);
+    assert_eq!(app.world.enemies.len(), 1, "Non-colliding enemy should survive checkpoint respawn");
+    assert_ne!(
+        app.world.enemies[0].position, far_enemy_pos,
+        "Surviving enemy should have moved via BFS"
+    );
 }
 
 #[test]
 fn enemy_on_checkpoint_tile_is_pushed_on_respawn() {
     let map = test_map(20, 20);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = 10;
+    app.player.hp = 10;
     let checkpoint = Position { x: 10, y: 10 };
-    app.last_checkpoint = Some(checkpoint);
-    app.activated_torchlights.insert(checkpoint);
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
-    app.enemies.push(Enemy { position: checkpoint, hp: Some(30), ..Enemy::new(checkpoint) });
+    app.player.last_checkpoint = Some(checkpoint);
+    app.world.activated_torchlights.insert(checkpoint);
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.world.enemies.push(Enemy { position: checkpoint, hp: Some(30), ..Enemy::new(checkpoint) });
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert_eq!(app.game_state, GameState::Dying);
+    assert_eq!(app.session.game_state, GameState::Dying);
     tick(&mut app, ATTACK_EFFECT_MS);
     tick(&mut app, 0.0);
-    assert_eq!(app.game_state, GameState::Playing);
-    assert_eq!(app.player.position, checkpoint, "Player should be at checkpoint");
-    let enemy_on_checkpoint = app.enemies.iter().any(|e| e.position == checkpoint);
+    assert_eq!(app.session.game_state, GameState::Playing);
+    assert_eq!(app.player.inner.position, checkpoint, "Player should be at checkpoint");
+    let enemy_on_checkpoint = app.world.enemies.iter().any(|e| e.position == checkpoint);
     assert!(!enemy_on_checkpoint, "Enemy should be pushed off checkpoint tile");
-    assert_eq!(app.enemies.len(), 1, "One surviving enemy after respawn");
+    assert_eq!(app.world.enemies.len(), 1, "One surviving enemy after respawn");
 }
 
 #[test]
 fn level_transition_clears_checkpoints() {
     let map = test_map(20, 20);
     let mut app = started_app_with_map(map, Position { x: 3, y: 3 });
-    app.last_checkpoint = Some(Position { x: 10, y: 10 });
-    app.activated_torchlights.insert(Position { x: 10, y: 10 });
+    app.player.last_checkpoint = Some(Position { x: 10, y: 10 });
+    app.world.activated_torchlights.insert(Position { x: 10, y: 10 });
 
     app.advance_level();
 
-    assert_eq!(app.last_checkpoint, None, "Checkpoint should be cleared on level advance");
-    assert!(app.activated_torchlights.is_empty(), "Torchlights should be cleared on level advance");
+    assert_eq!(app.player.last_checkpoint, None, "Checkpoint should be cleared on level advance");
+    assert!(
+        app.world.activated_torchlights.is_empty(),
+        "Torchlights should be cleared on level advance"
+    );
 }
 
 #[test]
 fn level_4_enemies_have_hp_from_advance_level() {
     let mut app = App::new();
-    app.started = true;
-    app.level = 3;
+    app.session.started = true;
+    app.player.level = 3;
     app.advance_level();
-    assert_eq!(app.level, 4);
-    assert!(!app.enemies.is_empty(), "Level 4 should have enemy spawns");
-    for enemy in &app.enemies {
+    assert_eq!(app.player.level, 4);
+    assert!(!app.world.enemies.is_empty(), "Level 4 should have enemy spawns");
+    for enemy in &app.world.enemies {
         assert!(enemy.hp.is_some(), "Level 4 enemies should have hp: Some(N)");
         assert_eq!(enemy.hp, Some(30), "Level 4 enemies should have 30 HP");
     }
@@ -1403,12 +1434,12 @@ fn level_4_enemies_have_hp_from_advance_level() {
 #[test]
 fn level_3_enemies_have_no_hp() {
     let mut app = App::new();
-    app.started = true;
-    app.level = 2;
+    app.session.started = true;
+    app.player.level = 2;
     app.advance_level();
-    assert_eq!(app.level, 3);
-    if !app.enemies.is_empty() {
-        for enemy in &app.enemies {
+    assert_eq!(app.player.level, 3);
+    if !app.world.enemies.is_empty() {
+        for enemy in &app.world.enemies {
             assert!(
                 enemy.hp.is_none(),
                 "Level 3 enemies should have hp: None (despawn on contact)"
@@ -1420,16 +1451,16 @@ fn level_3_enemies_have_no_hp() {
 #[test]
 fn level_4_retry_level_enemies_have_hp() {
     let mut app = App::new();
-    app.started = true;
-    app.level = 3;
+    app.session.started = true;
+    app.player.level = 3;
     app.advance_level();
-    assert_eq!(app.level, 4);
-    app.hp = 0;
-    app.game_state = GameState::Lost;
+    assert_eq!(app.player.level, 4);
+    app.player.hp = 0;
+    app.session.game_state = GameState::Lost;
     app.retry_level();
-    assert_eq!(app.level, 4);
-    assert!(!app.enemies.is_empty(), "Level 4 should have enemy spawns after retry");
-    for enemy in &app.enemies {
+    assert_eq!(app.player.level, 4);
+    assert!(!app.world.enemies.is_empty(), "Level 4 should have enemy spawns after retry");
+    for enemy in &app.world.enemies {
         assert!(enemy.hp.is_some(), "Level 4 enemies after retry should have hp: Some(N)");
         assert_eq!(enemy.hp, Some(30), "Level 4 enemies after retry should have 30 HP");
     }
@@ -1438,11 +1469,11 @@ fn level_4_retry_level_enemies_have_hp() {
 #[test]
 fn level_1_and_2_enemies_have_no_hp() {
     let mut app = App::new();
-    app.started = true;
-    app.level = 1;
+    app.session.started = true;
+    app.player.level = 1;
     app.advance_level();
-    assert_eq!(app.level, 2);
-    assert!(app.enemies.is_empty(), "Level 2 should have no enemies");
+    assert_eq!(app.player.level, 2);
+    assert!(app.world.enemies.is_empty(), "Level 2 should have no enemies");
 }
 
 #[test]
@@ -1451,14 +1482,14 @@ fn level_4_colliding_enemy_persists_on_checkpoint_respawn() {
     // unlike Level 3 enemies (hp: None) which despawn on contact.
     let map = test_map(20, 20);
     let mut app = started_app_with_map(map, Position { x: 5, y: 5 });
-    app.level = 4;
-    app.hp = 10;
+    app.player.level = 4;
+    app.player.hp = 10;
     let checkpoint = Position { x: 10, y: 10 };
-    app.last_checkpoint = Some(checkpoint);
-    app.activated_torchlights.insert(checkpoint);
-    app.player.last_direction = Some(Direction::Right);
+    app.player.last_checkpoint = Some(checkpoint);
+    app.world.activated_torchlights.insert(checkpoint);
+    app.player.inner.last_direction = Some(Direction::Right);
     // Level 4 enemy with hp: Some(30)
-    app.enemies = vec![Enemy {
+    app.world.enemies = vec![Enemy {
         position: Position { x: 6, y: 5 },
         hp: Some(30),
         ..Enemy::new(Position { x: 6, y: 5 })
@@ -1467,18 +1498,18 @@ fn level_4_colliding_enemy_persists_on_checkpoint_respawn() {
     // Move right — enemy steps toward player, collision occurs, HP -> 0 -> checkpoint respawn
     vim_rogue::game::handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.game_state, GameState::Dying);
+    assert_eq!(app.session.game_state, GameState::Dying);
     tick(&mut app, ATTACK_EFFECT_MS);
     tick(&mut app, 0.0);
 
     // Player should have respawned at checkpoint
-    assert_eq!(app.hp, MAX_HP, "HP should be restored to MAX_HP");
-    assert_eq!(app.player.position, checkpoint, "Player should respawn at checkpoint");
-    assert_eq!(app.game_state, GameState::Playing, "Should be Playing after respawn");
+    assert_eq!(app.player.hp, MAX_HP, "HP should be restored to MAX_HP");
+    assert_eq!(app.player.inner.position, checkpoint, "Player should respawn at checkpoint");
+    assert_eq!(app.session.game_state, GameState::Playing, "Should be Playing after respawn");
 
     // The Level 4 enemy should persist (not despawn)
-    assert_eq!(app.enemies.len(), 1, "Level 4 enemy should persist after collision");
-    assert_eq!(app.enemies[0].hp, Some(30), "Level 4 enemy HP should be unchanged");
+    assert_eq!(app.world.enemies.len(), 1, "Level 4 enemy should persist after collision");
+    assert_eq!(app.world.enemies[0].hp, Some(30), "Level 4 enemy HP should be unchanged");
 }
 
 #[test]
@@ -1537,7 +1568,7 @@ fn advance_level_clears_attack_effects() {
         0,
     ));
     assert!(!app.attack_effects.is_empty());
-    app.level = 1;
+    app.player.level = 1;
     handle_key(&mut app, VirtualKeyCode::L, false);
     assert!(app.attack_effects.is_empty());
 }
@@ -1555,8 +1586,8 @@ fn retry_level_clears_attack_effects() {
 fn enemy_collision_spawns_hit_effect_on_player() {
     let map = test_map(5, 5);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = MAX_HP;
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.player.hp = MAX_HP;
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
     handle_key(&mut app, VirtualKeyCode::H, false);
     assert_eq!(app.attack_effects.len(), 1);
     let effect = &app.attack_effects[0];
@@ -1569,10 +1600,10 @@ fn enemy_collision_spawns_hit_effect_on_player() {
 fn fatal_enemy_hit_preserves_effect() {
     let map = test_map(5, 5);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = 10;
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.player.hp = 10;
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
     handle_key(&mut app, VirtualKeyCode::H, false);
-    assert_eq!(app.game_state, GameState::Dying);
+    assert_eq!(app.session.game_state, GameState::Dying);
     assert_eq!(app.attack_effects.len(), 1);
     assert_eq!(app.attack_effects[0].kind, AttackEffectKind::EnemyHit);
 }
@@ -1581,32 +1612,32 @@ fn fatal_enemy_hit_preserves_effect() {
 fn checkpoint_respawn_preserves_hit_effect() {
     let map = test_map(20, 20);
     let mut app = started_app_with_map(map, Position { x: 5, y: 5 });
-    app.level = 4;
-    app.hp = 10;
+    app.player.level = 4;
+    app.player.hp = 10;
     let checkpoint = Position { x: 10, y: 10 };
-    app.last_checkpoint = Some(checkpoint);
-    app.activated_torchlights.insert(checkpoint);
-    app.player.last_direction = Some(Direction::Right);
-    app.enemies = vec![Enemy {
+    app.player.last_checkpoint = Some(checkpoint);
+    app.world.activated_torchlights.insert(checkpoint);
+    app.player.inner.last_direction = Some(Direction::Right);
+    app.world.enemies = vec![Enemy {
         position: Position { x: 6, y: 5 },
         hp: Some(30),
         ..Enemy::new(Position { x: 6, y: 5 })
     }];
     handle_key(&mut app, VirtualKeyCode::L, false);
-    assert_eq!(app.game_state, GameState::Dying);
+    assert_eq!(app.session.game_state, GameState::Dying);
     assert!(!app.attack_effects.is_empty());
     tick(&mut app, ATTACK_EFFECT_MS);
     tick(&mut app, 0.0);
-    assert_eq!(app.game_state, GameState::Playing);
-    assert_eq!(app.player.position, checkpoint);
+    assert_eq!(app.session.game_state, GameState::Playing);
+    assert_eq!(app.player.inner.position, checkpoint);
 }
 
 #[test]
 fn attack_effects_expire_after_duration() {
     let map = test_map(5, 5);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = MAX_HP;
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.player.hp = MAX_HP;
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
     handle_key(&mut app, VirtualKeyCode::H, false);
     assert_eq!(app.attack_effects.len(), 1);
     tick(&mut app, ATTACK_EFFECT_MS); // ages to complete, still present
@@ -1618,25 +1649,25 @@ fn attack_effects_expire_after_duration() {
 fn dying_transitions_to_lost_after_effects_expire() {
     let map = test_map(5, 5);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = 10;
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.player.hp = 10;
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
     handle_key(&mut app, VirtualKeyCode::H, false);
-    assert_eq!(app.game_state, GameState::Dying);
+    assert_eq!(app.session.game_state, GameState::Dying);
     tick(&mut app, ATTACK_EFFECT_MS);
-    assert_eq!(app.game_state, GameState::Dying);
+    assert_eq!(app.session.game_state, GameState::Dying);
     tick(&mut app, 0.0);
-    assert_eq!(app.game_state, GameState::Lost);
+    assert_eq!(app.session.game_state, GameState::Lost);
 }
 
 #[test]
 fn nonfatal_effect_survives_oversized_first_delta() {
     let map = test_map(5, 5);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = MAX_HP;
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.player.hp = MAX_HP;
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
     handle_key(&mut app, VirtualKeyCode::H, false);
     assert_eq!(app.attack_effects.len(), 1);
-    assert_eq!(app.game_state, GameState::Playing);
+    assert_eq!(app.session.game_state, GameState::Playing);
     tick(&mut app, ATTACK_EFFECT_MS * 10.0);
     assert_eq!(
         app.attack_effects.len(),
@@ -1660,42 +1691,46 @@ fn player_strike_survives_oversized_first_delta() {
 fn dying_state_ignores_input() {
     let map = test_map(5, 5);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = 10;
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.player.hp = 10;
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
     handle_key(&mut app, VirtualKeyCode::H, false);
-    assert_eq!(app.game_state, GameState::Dying);
-    let pos_before = app.player.position;
+    assert_eq!(app.session.game_state, GameState::Dying);
+    let pos_before = app.player.inner.position;
     handle_key(&mut app, VirtualKeyCode::L, false);
-    assert_eq!(app.player.position, pos_before, "input should be ignored during Dying");
+    assert_eq!(app.player.inner.position, pos_before, "input should be ignored during Dying");
 }
 
 #[test]
 fn dying_large_delta_still_shows_effects_before_transition() {
     let map = test_map(5, 5);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = 10;
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.player.hp = 10;
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
     handle_key(&mut app, VirtualKeyCode::H, false);
-    assert_eq!(app.game_state, GameState::Dying);
+    assert_eq!(app.session.game_state, GameState::Dying);
     tick(&mut app, ATTACK_EFFECT_MS * 10.0);
-    assert_eq!(app.game_state, GameState::Dying, "effects still visible after oversized delta");
+    assert_eq!(
+        app.session.game_state,
+        GameState::Dying,
+        "effects still visible after oversized delta"
+    );
     assert!(!app.attack_effects.is_empty(), "effects should not be cleared during Dying");
     assert!(app.attack_effects.iter().all(|e| e.is_complete()));
     tick(&mut app, 0.0);
-    assert_eq!(app.game_state, GameState::Lost);
+    assert_eq!(app.session.game_state, GameState::Lost);
 }
 
 #[test]
 fn two_enemies_same_turn_both_hit_at_high_hp() {
     let map = test_map(10, 3);
     let mut app = started_app_with_map(map, Position { x: 5, y: 1 });
-    app.hp = 20;
-    app.enemies.push(Enemy::new(Position { x: 4, y: 0 }));
-    app.enemies.push(Enemy::new(Position { x: 4, y: 2 }));
+    app.player.hp = 20;
+    app.world.enemies.push(Enemy::new(Position { x: 4, y: 0 }));
+    app.world.enemies.push(Enemy::new(Position { x: 4, y: 2 }));
     handle_key(&mut app, VirtualKeyCode::H, false);
-    assert_eq!(app.player.position, Position { x: 4, y: 1 });
-    assert_eq!(app.hp, 0);
-    assert_eq!(app.game_state, GameState::Dying);
+    assert_eq!(app.player.inner.position, Position { x: 4, y: 1 });
+    assert_eq!(app.player.hp, 0);
+    assert_eq!(app.session.game_state, GameState::Dying);
     assert_eq!(app.attack_effects.len(), 2);
 }
 
@@ -1703,12 +1738,12 @@ fn two_enemies_same_turn_both_hit_at_high_hp() {
 fn two_enemies_fatal_first_skips_second() {
     let map = test_map(5, 5);
     let mut app = started_app_with_map(map, Position { x: 3, y: 0 });
-    app.hp = 10;
-    app.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
-    app.enemies.push(Enemy::new(Position { x: 4, y: 0 }));
+    app.player.hp = 10;
+    app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
+    app.world.enemies.push(Enemy::new(Position { x: 4, y: 0 }));
     handle_key(&mut app, VirtualKeyCode::H, false);
-    assert_eq!(app.hp, 0);
-    assert_eq!(app.game_state, GameState::Dying);
+    assert_eq!(app.player.hp, 0);
+    assert_eq!(app.session.game_state, GameState::Dying);
     assert_eq!(app.attack_effects.len(), 1, "second enemy skipped after fatal collision");
 }
 
@@ -1717,30 +1752,30 @@ fn checkpoint_respawn_pushes_stacked_enemies_off_checkpoint() {
     let map = test_map(10, 10);
     let checkpoint = Position { x: 5, y: 5 };
     let mut app = started_app_with_map(map, Position { x: 5, y: 6 });
-    app.level = 4;
-    app.hp = 10;
-    app.last_checkpoint = Some(checkpoint);
-    app.activated_torchlights.insert(checkpoint);
-    app.player.last_direction = Some(Direction::Up);
-    app.enemies = vec![
+    app.player.level = 4;
+    app.player.hp = 10;
+    app.player.last_checkpoint = Some(checkpoint);
+    app.world.activated_torchlights.insert(checkpoint);
+    app.player.inner.last_direction = Some(Direction::Up);
+    app.world.enemies = vec![
         Enemy { position: checkpoint, hp: Some(30), ..Enemy::new(checkpoint) },
         Enemy { position: checkpoint, hp: Some(30), ..Enemy::new(checkpoint) },
     ];
     handle_key(&mut app, VirtualKeyCode::K, false);
-    assert_eq!(app.player.position, Position { x: 5, y: 5 });
-    assert_eq!(app.game_state, GameState::Dying);
+    assert_eq!(app.player.inner.position, Position { x: 5, y: 5 });
+    assert_eq!(app.session.game_state, GameState::Dying);
     tick(&mut app, ATTACK_EFFECT_MS);
     tick(&mut app, 0.0);
-    assert_eq!(app.game_state, GameState::Playing);
-    assert_eq!(app.player.position, checkpoint);
-    assert_eq!(app.enemies.len(), 2);
-    let on_checkpoint = app.enemies.iter().any(|e| e.position == checkpoint);
+    assert_eq!(app.session.game_state, GameState::Playing);
+    assert_eq!(app.player.inner.position, checkpoint);
+    assert_eq!(app.world.enemies.len(), 2);
+    let on_checkpoint = app.world.enemies.iter().any(|e| e.position == checkpoint);
     assert!(!on_checkpoint, "no enemy should remain on checkpoint tile");
     let positions: std::collections::HashSet<Position> =
-        app.enemies.iter().map(|e| e.position).collect();
+        app.world.enemies.iter().map(|e| e.position).collect();
     assert_eq!(
         positions.len(),
-        app.enemies.len(),
+        app.world.enemies.len(),
         "enemies should not stack on the same tile after push"
     );
 }
@@ -1754,21 +1789,21 @@ fn push_enemies_bfs_respects_walls() {
     map.set_tile(5, 4, Tile::Wall);
     map.set_tile(5, 6, Tile::Wall);
     let mut app = started_app_with_map(map, Position { x: 8, y: 8 });
-    app.game_state = GameState::Dying;
-    app.pending_respawn = Some(checkpoint);
+    app.session.game_state = GameState::Dying;
+    app.player.pending_respawn = Some(checkpoint);
     app.attack_effects.push(AttackEffect::new(AttackEffectKind::EnemyHit, 8, 8));
-    app.enemies = vec![
+    app.world.enemies = vec![
         Enemy { position: checkpoint, hp: Some(30), ..Enemy::new(checkpoint) },
         Enemy { position: checkpoint, hp: Some(30), ..Enemy::new(checkpoint) },
     ];
     tick(&mut app, ATTACK_EFFECT_MS);
     tick(&mut app, 0.0);
-    assert_eq!(app.game_state, GameState::Playing);
-    assert_eq!(app.player.position, checkpoint);
-    assert_eq!(app.enemies.len(), 2);
+    assert_eq!(app.session.game_state, GameState::Playing);
+    assert_eq!(app.player.inner.position, checkpoint);
+    assert_eq!(app.world.enemies.len(), 2);
     // Enemies stay at checkpoint since all neighbors are impassable walls
     assert!(
-        app.enemies.iter().all(|e| e.position == checkpoint),
+        app.world.enemies.iter().all(|e| e.position == checkpoint),
         "BFS should not push enemies through walls"
     );
 }
@@ -1777,11 +1812,11 @@ fn push_enemies_bfs_respects_walls() {
 fn dying_with_empty_effects_transitions_immediately() {
     let map = test_map(5, 5);
     let mut app = started_app_with_map(map, Position { x: 2, y: 2 });
-    app.game_state = GameState::Dying;
-    app.pending_respawn = None;
+    app.session.game_state = GameState::Dying;
+    app.player.pending_respawn = None;
     assert!(app.attack_effects.is_empty());
     tick(&mut app, 0.0);
-    assert_eq!(app.game_state, GameState::Lost);
+    assert_eq!(app.session.game_state, GameState::Lost);
 }
 
 #[test]
@@ -1789,38 +1824,41 @@ fn mixed_age_dying_removes_completed_effects_first() {
     let map = test_map(10, 10);
     let checkpoint = Position { x: 5, y: 5 };
     let mut app = started_app_with_map(map, Position { x: 5, y: 5 });
-    app.hp = 10;
-    app.last_checkpoint = Some(checkpoint);
-    app.activated_torchlights.insert(checkpoint);
+    app.player.hp = 10;
+    app.player.last_checkpoint = Some(checkpoint);
+    app.world.activated_torchlights.insert(checkpoint);
     let mut old_effect = AttackEffect::new(AttackEffectKind::EnemyHit, 5, 5);
     old_effect.update(ATTACK_EFFECT_MS);
     assert!(old_effect.is_complete());
     app.attack_effects.push(old_effect);
     app.attack_effects.push(AttackEffect::new(AttackEffectKind::EnemyHit, 5, 5));
-    app.game_state = GameState::Dying;
-    app.pending_respawn = Some(checkpoint);
+    app.session.game_state = GameState::Dying;
+    app.player.pending_respawn = Some(checkpoint);
     assert_eq!(app.attack_effects.len(), 2);
     tick(&mut app, 0.0);
     assert_eq!(app.attack_effects.len(), 1, "completed old effect should be removed");
     assert!(!app.attack_effects[0].is_complete(), "fresh effect should remain");
     tick(&mut app, ATTACK_EFFECT_MS);
     tick(&mut app, 0.0);
-    assert_eq!(app.game_state, GameState::Playing);
+    assert_eq!(app.session.game_state, GameState::Playing);
 }
 
 #[test]
 fn enemy_chases_when_player_visible() {
     let map = test_map(20, 20);
     let mut app = started_app_with_map(map, Position { x: 15, y: 10 });
-    app.level = 3;
+    app.player.level = 3;
     let mut enemy = Enemy::new(Position { x: 12, y: 10 });
     enemy.patrol_area = PatrolArea { min_x: 0, min_y: 0, max_x: 19, max_y: 19 };
-    app.enemies = vec![enemy];
+    app.world.enemies = vec![enemy];
 
-    let old_pos = app.enemies[0].position;
+    let old_pos = app.world.enemies[0].position;
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert_ne!(app.enemies[0].position, old_pos, "Enemy should move toward player when visible");
+    assert_ne!(
+        app.world.enemies[0].position, old_pos,
+        "Enemy should move toward player when visible"
+    );
 }
 
 #[test]
@@ -1830,19 +1868,21 @@ fn enemy_patrols_when_player_not_visible() {
         map.set_tile(40, y, Tile::Wall);
     }
     let mut app = started_app_with_map(map, Position { x: 60, y: 20 });
-    app.level = 3;
+    app.player.level = 3;
     let mut enemy = Enemy::new(Position { x: 10, y: 20 });
     enemy.patrol_area = PatrolArea { min_x: 0, min_y: 0, max_x: 39, max_y: 39 };
-    app.enemies = vec![enemy];
+    app.world.enemies = vec![enemy];
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
     assert!(
-        app.enemies[0].patrol_area.contains(app.enemies[0].position.x, app.enemies[0].position.y),
+        app.world.enemies[0]
+            .patrol_area
+            .contains(app.world.enemies[0].position.x, app.world.enemies[0].position.y),
         "Enemy should stay within patrol area"
     );
     assert_ne!(
-        app.enemies[0].position.x, 60,
+        app.world.enemies[0].position.x, 60,
         "Enemy should NOT be moving toward distant player behind wall"
     );
 }
@@ -1851,20 +1891,20 @@ fn enemy_patrols_when_player_not_visible() {
 fn enemy_patrol_does_not_leave_room_over_many_turns() {
     let map = test_map(80, 40);
     let mut app = started_app_with_map(map, Position { x: 70, y: 35 });
-    app.level = 3;
+    app.player.level = 3;
     let mut enemy = Enemy::new(Position { x: 10, y: 5 });
     enemy.patrol_area = PatrolArea { min_x: 4, min_y: 2, max_x: 15, max_y: 9 };
-    app.enemies = vec![enemy];
+    app.world.enemies = vec![enemy];
 
     for _ in 0..50 {
         handle_key(&mut app, VirtualKeyCode::L, false);
         assert!(
-            app.enemies[0]
+            app.world.enemies[0]
                 .patrol_area
-                .contains(app.enemies[0].position.x, app.enemies[0].position.y),
+                .contains(app.world.enemies[0].position.x, app.world.enemies[0].position.y),
             "Enemy left patrol area at ({}, {})",
-            app.enemies[0].position.x,
-            app.enemies[0].position.y
+            app.world.enemies[0].position.x,
+            app.world.enemies[0].position.y
         );
     }
 }
@@ -1873,22 +1913,22 @@ fn enemy_patrol_does_not_leave_room_over_many_turns() {
 #[cfg(debug_assertions)]
 fn cheat_iv_advances_to_next_level() {
     let mut app = started_app_with_map(test_map(10, 10), Position { x: 5, y: 5 });
-    assert_eq!(app.level, 1);
+    assert_eq!(app.player.level, 1);
     handle_key(&mut app, VirtualKeyCode::I, false);
     handle_key(&mut app, VirtualKeyCode::V, false);
-    assert_eq!(app.level, 2);
-    assert!(app.status_message.contains("CHEAT"));
+    assert_eq!(app.player.level, 2);
+    assert!(app.session.status_message.contains("CHEAT"));
 }
 
 #[test]
 #[cfg(debug_assertions)]
 fn cheat_iv_on_last_level_triggers_win() {
     let mut app = started_app_with_map(test_map(10, 10), Position { x: 5, y: 5 });
-    app.level = TOTAL_LEVELS;
+    app.player.level = TOTAL_LEVELS;
     handle_key(&mut app, VirtualKeyCode::I, false);
     handle_key(&mut app, VirtualKeyCode::V, false);
-    assert_eq!(app.game_state, GameState::Won);
-    assert!(app.status_message.contains("CHEAT"));
+    assert_eq!(app.session.game_state, GameState::Won);
+    assert!(app.session.status_message.contains("CHEAT"));
 }
 
 #[test]
@@ -1899,56 +1939,56 @@ fn cheat_im_toggles_god_mode() {
     handle_key(&mut app, VirtualKeyCode::I, false);
     handle_key(&mut app, VirtualKeyCode::M, false);
     assert!(app.cheat_god_mode);
-    assert!(app.status_message.contains("God mode ON"));
+    assert!(app.session.status_message.contains("God mode ON"));
     handle_key(&mut app, VirtualKeyCode::I, false);
     handle_key(&mut app, VirtualKeyCode::M, false);
     assert!(!app.cheat_god_mode);
-    assert!(app.status_message.contains("God mode OFF"));
+    assert!(app.session.status_message.contains("God mode OFF"));
 }
 
 #[test]
 #[cfg(debug_assertions)]
 fn cheat_god_mode_prevents_damage() {
     let mut app = level4_app_with_enemy(Position { x: 5, y: 5 }, None);
-    let hp_before = app.hp;
+    let hp_before = app.player.hp;
     handle_key(&mut app, VirtualKeyCode::I, false);
     handle_key(&mut app, VirtualKeyCode::M, false);
     assert!(app.cheat_god_mode);
     handle_key(&mut app, VirtualKeyCode::L, false);
-    assert_eq!(app.hp, hp_before, "God mode should prevent damage");
-    assert_eq!(app.game_state, GameState::Playing);
+    assert_eq!(app.player.hp, hp_before, "God mode should prevent damage");
+    assert_eq!(app.session.game_state, GameState::Playing);
 }
 
 #[test]
 #[cfg(debug_assertions)]
 fn cheat_ie_kills_all_enemies() {
     let mut app = level4_app_with_enemy(Position { x: 10, y: 10 }, Some(30));
-    app.enemies.push(Enemy {
+    app.world.enemies.push(Enemy {
         position: Position { x: 15, y: 15 },
         hp: Some(30),
         ..Enemy::new(Position { x: 15, y: 15 })
     });
-    assert_eq!(app.enemies.len(), 2);
+    assert_eq!(app.world.enemies.len(), 2);
     handle_key(&mut app, VirtualKeyCode::I, false);
     handle_key(&mut app, VirtualKeyCode::E, false);
-    assert!(app.enemies.is_empty());
+    assert!(app.world.enemies.is_empty());
     assert!(app.enemy_animations.is_empty());
-    assert!(app.status_message.contains("CHEAT"));
+    assert!(app.session.status_message.contains("CHEAT"));
 }
 
 #[test]
 #[cfg(debug_assertions)]
 fn cheat_ip_toggles_noclip() {
     let mut app = started_app_with_map(test_map(10, 10), Position { x: 5, y: 5 });
-    assert!(!app.player.noclip);
+    assert!(!app.player.inner.noclip);
     handle_key(&mut app, VirtualKeyCode::I, false);
     handle_key(&mut app, VirtualKeyCode::P, false);
-    assert!(app.player.noclip);
-    assert!(app.status_message.contains("Noclip ON"));
+    assert!(app.player.inner.noclip);
+    assert!(app.session.status_message.contains("Noclip ON"));
     handle_key(&mut app, VirtualKeyCode::I, false);
     handle_key(&mut app, VirtualKeyCode::P, false);
-    assert!(!app.player.noclip);
-    assert!(app.status_message.contains("Noclip OFF"));
+    assert!(!app.player.inner.noclip);
+    assert!(app.session.status_message.contains("Noclip OFF"));
 }
 
 #[test]
@@ -1958,11 +1998,11 @@ fn cheat_noclip_allows_wall_walking() {
     map.set_tile(6, 5, Tile::Wall);
     let mut app = started_app_with_map(map, Position { x: 5, y: 5 });
     handle_key(&mut app, VirtualKeyCode::L, false);
-    assert_eq!(app.player.position, Position { x: 5, y: 5 });
+    assert_eq!(app.player.inner.position, Position { x: 5, y: 5 });
     handle_key(&mut app, VirtualKeyCode::I, false);
     handle_key(&mut app, VirtualKeyCode::P, false);
     handle_key(&mut app, VirtualKeyCode::L, false);
-    assert_eq!(app.player.position, Position { x: 6, y: 5 });
+    assert_eq!(app.player.inner.position, Position { x: 6, y: 5 });
 }
 
 #[test]
@@ -1972,5 +2012,5 @@ fn cheat_buffer_resets_on_non_char_key() {
     handle_key(&mut app, VirtualKeyCode::I, false);
     handle_key(&mut app, VirtualKeyCode::Escape, false);
     handle_key(&mut app, VirtualKeyCode::V, false);
-    assert_eq!(app.level, 1);
+    assert_eq!(app.player.level, 1);
 }

--- a/tests/renderer.rs
+++ b/tests/renderer.rs
@@ -221,7 +221,8 @@ fn rgb8_converts_correctly() {
 #[test]
 fn visual_enemy_positions_use_active_animation() {
     let mut app = test_app();
-    app.enemies
+    app.world
+        .enemies
         .push(Enemy { position: Position { x: 4, y: 2 }, ..Enemy::new(Position { x: 4, y: 2 }) });
     let mut animation = AnimationState::new(ENEMY_MOVE_MS, (2.0, 2.0), (4.0, 2.0));
     animation.update(ENEMY_MOVE_MS / 2.0);
@@ -327,14 +328,14 @@ fn minimap_scaling_covers_full_map() {
 fn minimap_hidden_tile_is_blank() {
     let mut app = test_app();
     let pos = Position { x: 10, y: 10 };
-    app.map.set_tile(10, 10, Tile::Floor);
-    assert_eq!(app.visibility.get(pos), VisibilityState::Hidden);
+    app.world.map.set_tile(10, 10, Tile::Floor);
+    assert_eq!(app.world.visibility.get(pos), VisibilityState::Hidden);
 }
 
 #[test]
 fn minimap_player_position_at_start() {
     let app = test_app();
-    let (px, py) = minimap_player_pos(app.player.position.x, app.player.position.y);
+    let (px, py) = minimap_player_pos(app.player.inner.position.x, app.player.inner.position.y);
     assert!(px >= 0 && px < MINIMAP_WIDTH as i32, "player minimap x should be in range, got {px}");
     assert!(py >= 0 && py < MINIMAP_HEIGHT as i32, "player minimap y should be in range, got {py}");
 }


### PR DESCRIPTION
## Summary
- Decompose 29-field `App` struct into 4 focused aggregates: `World`, `PlayerState`, `InputState`, `Session`
- Move reset logic, visibility computation, and status message generation into their owning aggregates
- App becomes a thin coordinator — sequences cross-aggregate flows but owns no logic

## Changes

| Step | Lines changed |
|------|---------------|
| Create aggregate structs, migrate fields | +1325/-762 |
| Move reset logic into aggregate methods | +68/-61 |
| Move update_visibility into World | +27/-36 |
| Extract motion/damage feedback into PlayerState | +21/-26 |

**Before:** `App` had 29 `pub` fields. Every function touched unrelated fields.

**After:** `App` has 8 fields. Each aggregate owns its own constructors and methods.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — 393 pass, no behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)