### PR TITLE
refactor(player): merge Player into PlayerState

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Generated: 2026-04-17 | Updated: 2026-04-29 -->
-<!-- Commit: 45519e5 | Branch: refactor/aggregate-app-split -->
+<!-- Commit: HEAD | Branch: refactor/merge-player-into-playerstate -->
 
 # vim-rogue
 
@@ -9,7 +9,7 @@ Roguelike dungeon game (Rust + bracket-lib). Teaches Vim motions through gamepla
 ```
 vim-rogue/
 ├── src/          # Application source code (see src/AGENTS.md)
-├── tests/        # Integration tests — 393 tests across 9 files (see tests/AGENTS.md)
+├── tests/        # Integration tests — 396 tests across 9 files (see tests/AGENTS.md)
 ├── examples/     # Spike/prototype code (spike.rs)
 ├── resources/    # CP437 font sprite sheets (PNG) for bracket-lib rendering
 ├── Cargo.toml    # Edition 2024, deps: anyhow (unused), bracket-lib
@@ -22,10 +22,10 @@ vim-rogue/
 ```
 main.rs       → bracket-lib setup + event loop (44 lines)
 game.rs       → App coordinator — sequences cross-aggregate flows: level transitions, collision→damage, pause/resume (740 lines)
-player.rs     → Player + 13 motion implementations (262 lines)
+player.rs     → PlayerState impl — 13 motions + motion tracking (260 lines)
 map.rs        → 80×40 grid, 5 zones, 4 dungeon levels, corridor carving, enemy spawns + patrol areas (471 lines)
 renderer.rs   → bracket-lib rendering: title, viewport, sidebar, minimap, win/loss screens, ASCII art (914 lines)
-types.rs      → Position, Tile, Zone, VimMotion, Direction, Enemy, PatrolArea, App + 4 aggregates (World, PlayerState, InputState, Session), RenderGrid, ViewModel (566 lines)
+types.rs      → Position, Tile, Zone, VimMotion, Direction, Enemy, PatrolArea, PlayerState (position, motions, noclip), App + 3 aggregates (World, InputState, Session), RenderGrid, ViewModel (560 lines)
 animation.rs  → GameClock, AnimationState, AnimationTimer, Interpolator (easing) (182 lines)
 visibility.rs → VisibilityMap with FOV (explored/visible/hidden states) (124 lines)
 enemy.rs      → Enemy struct with FOV-aware BFS chase + room patrol (180 lines)
@@ -36,7 +36,7 @@ lib.rs        → Re-exports all modules (9 lines)
 ## Where To Look
 | Task | Location | Notes |
 |------|----------|-------|
-| Add new Vim motion | `src/player.rs` + `src/types.rs` (VimMotion enum) | Update `game.rs` parse_motion too |
+| Add new Vim motion | `src/player.rs` + `src/types.rs` (VimMotion enum) | handle_motion on PlayerState; Update `game.rs` parse_motion too |
 | Change dungeon layout | `src/map.rs` (carve_level, build_level_2/3/4) | `grid[y][x]` row-major; 4 levels |
 | Add UI elements | `src/renderer.rs` | Display only — never mutates state |
 | Change game flow | `src/game.rs` (handle_key, tick, execute_motion) | Two-phase input for f/t/dd/gg; ESC/q = pause |
@@ -44,21 +44,21 @@ lib.rs        → Re-exports all modules (9 lines)
 | Add new types | `src/types.rs` | All modules use `crate::types::*` |
 | Change enemy AI | `src/enemy.rs` (step_toward_player, has_line_of_sight, patrol_step) | FOV-gated BFS chase + patrol, called from World.enemies_step |
 | Change FOV/visibility | `src/visibility.rs` (compute_fov) | Hidden/Explored/Visible states |
-| Change aggregate logic | `src/types.rs` (World, PlayerState, InputState, Session) | Each aggregate owns its domain; App coordinates |
+| Change aggregate logic | `src/types.rs` (World, InputState, Session) + `src/player.rs` (PlayerState) | PlayerState flat struct; each aggregate owns its domain; App coordinates |
 | Add animations | `src/animation.rs` | AnimationState + Interpolator; GameClock trait |
 | Add sound effects | `src/audio.rs` (SoundEffect enum + AudioManager) | Disabled by default |
-| Fix bug | `tests/` (393 integration tests, 9 files) | main.rs + lib.rs have no tests |
+| Fix bug | `tests/` (396 integration tests, 9 files) | main.rs + lib.rs have no tests |
 
 ## Conventions
 - Rust edition 2024. `rustfmt.toml`: `use_small_heuristics = "Max"`, `edition = "2024"`.
-- 393 integration tests in `tests/` (9 files). Shared helpers in `tests/common/mod.rs`.
+- 396 integration tests in `tests/` (9 files). Shared helpers in `tests/common/mod.rs`.
 - Helpers: `test_map()`, `started_app_with_map()`, `test_app()`, `assert_approx_eq()`, `approx_eq()`, `tick_timer()`, `tick_state()`.
 - `renderer.rs` internals `pub` for test access (e.g. `screen_meets_minimum_size`, `phase_definitions`, `exit_glow`).
 - `lib.rs` re-exports all. `main.rs` thin (~32 lines).
 - `is_passable` = `Tile::Floor`, `Tile::Exit`, `Tile::Torchlight`. `Tile::Obstacle` not passable but `dd` destroys it.
 - w/b: horizontal scan, stop at non-passable. G/gg: vertical scan, stop at non-passable.
 - `renderer.rs` read-only — never mutates App.
-- `Player::handle_motion` takes `&mut Map` (dd deletes obstacles).
+- `PlayerState::handle_motion` takes `&mut Map` (dd deletes obstacles). Owns motion tracking (motion_count, discovered_motions).
 - `GameClock` trait: `RealClock` prod, `TestClock` tests.
 - Animations: player 150ms (`PLAYER_MOVE_MS`), enemy 200ms (`ENEMY_MOVE_MS`).
 - FOV: `FOV_RADIUS` in types.rs. Enemy FOV: `ENEMY_FOV_RADIUS = 8`.
@@ -73,7 +73,7 @@ lib.rs        → Re-exports all modules (9 lines)
 cargo fmt              # Format code (uses rustfmt.toml)
 cargo fmt --check      # Check formatting without writing
 cargo clippy           # Lint
-cargo test             # Run 393 integration tests
+cargo test             # Run 396 integration tests
 cargo build            # Compile
 cargo run              # Launch game in terminal
 ```
@@ -82,7 +82,7 @@ cargo run              # Launch game in terminal
 After any code change, run all:
 1. `cargo fmt --check` — formatting clean
 2. `cargo clippy` — zero warnings
-3. `cargo test` — all 393 pass
+3. `cargo test` — all 396 pass
 4. Update `CHANGELOG.md` — add entry under `[Unreleased]` or new version
 
 ## Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Move reset logic into aggregate methods** — each aggregate owns its own constructors and reset behavior
 - **Move `update_visibility` into `World`** — FOV computation belongs to the aggregate that owns the map
 - **Extract motion/damage feedback into `PlayerState`** — status message generation lives with the aggregate that produces it
+- **Merge `Player` into `PlayerState`** — eliminate shallow `inner: Player` wrapper; PlayerState now holds position, used_motions, last_direction, noclip directly. `handle_motion` owns motion tracking (motion_count, discovered_motions)
 
 ### Tests
 
-- 393 integration tests (no behavior changes)
+- 396 integration tests (+3 covering motion_count and discovered_motions behavior)
 
 ## [0.2.2] - 2026-04-22
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Reach the exit (`>`) on each level. Complete all 4 levels to win. Lose all lives
 
 ```bash
 cargo build            # Compile
-cargo test             # Run 393 integration tests
+cargo test             # Run 396 integration tests
 cargo fmt              # Format code (uses rustfmt.toml)
 cargo fmt --check      # Check formatting without writing
 cargo clippy           # Lint
@@ -71,7 +71,7 @@ cargo run              # Play
 ```
 src/main.rs       bracket-lib BTerm setup + GameState event loop, quit handling
 src/game.rs       App coordinator — sequences cross-aggregate flows (level transitions, collision → damage, pause/resume)
-src/player.rs     Player + 13 motion implementations
+src/player.rs     PlayerState impl — 13 motion implementations + motion tracking
 src/map.rs        80×40 grid, 5 zones, corridor carving, 4 dungeon levels, enemy spawn points + patrol areas
 src/renderer.rs   bracket-lib rendering: title, viewport, sidebar, minimap, win/loss/pause screens, fog of war
 src/types.rs      Shared types (Position, Tile, Zone, VimMotion, Enemy, PatrolArea, GameState, PauseOption, App, aggregates, …)
@@ -84,7 +84,7 @@ src/lib.rs        Module re-exports
 
 ### Key Design Decisions
 
-- **Domain aggregates over god object** — `App` decomposed into `World` (terrain, visibility, enemies), `PlayerState` (position, HP, trail, progression), `InputState` (Vim key buffering), `Session` (lifecycle, timing, pause); `App` is a thin coordinator with no business logic
+- **Domain aggregates over god object** — `App` decomposed into `World` (terrain, visibility, enemies), `PlayerState` (position, motions, HP, trail, progression; impl in player.rs), `InputState` (Vim key buffering), `Session` (lifecycle, timing, pause); `App` is a thin coordinator with no business logic
 - **`renderer.rs` is read-only** — never mutates game state
 - **Deterministic timing** — `TestClock` for tests, `RealClock` for production (via `GameClock` trait)
 - **FOV-aware enemy AI** — enemies use Bresenham line-of-sight within their FOV radius to detect the player; they chase via BFS when visible and patrol their room when not

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-04-17 | Updated: 2026-04-29 -->
+<!-- Generated: 2026-04-17 | Updated: 2026-04-29 (PR#11) -->
 # src
 
 All vim-rogue source. Tests in `tests/` (integration only).
@@ -10,10 +10,10 @@ All vim-rogue source. Tests in `tests/` (integration only).
 | `main.rs` | 44 | Binary entry — bracket-lib setup, event loop, `ctx.quit()`, delegates to game/renderer |
 | `lib.rs` | 9 | Library root — `pub mod` re-exports |
 | `game.rs` | 740 | App coordinator — `handle_key`/`tick`, sequences cross-aggregate flows (level transitions, collision→damage, pause/resume) |
-| `player.rs` | 262 | `Player` + 13 motion impls (h/j/k/l/w/b/0/$/G/gg/f/t/dd) |
+| `player.rs` | 260 | `PlayerState` impl — 13 motions + motion tracking (h/j/k/l/w/b/0/$/G/gg/f/t/dd) |
 | `map.rs` | 471 | `Map`, 80×40 grid, 5 zones, 4 levels (`carve_level`, `build_level_2/3/4`), enemy spawns + patrol areas |
 | `renderer.rs` | 914 | bracket-lib render — title/gameplay/win/lost/pause screens, viewport, sidebar, minimap, zone colors |
-| `types.rs` | 566 | Position, Tile, Zone, VimMotion, Direction, Enemy, PatrolArea, App + 4 aggregates (World, PlayerState, InputState, Session), RenderGrid, ViewModel, ScreenModel |
+| `types.rs` | 560 | Position, Tile, Zone, VimMotion, Direction, Enemy, PatrolArea, PlayerState (position, motions, noclip), App + 3 aggregates (World, InputState, Session), RenderGrid, ViewModel, ScreenModel |
 | `animation.rs` | 182 | `GameClock` trait, `RealClock`/`TestClock`, `AnimationState`, `AnimationTimer`, `Interpolator` |
 | `visibility.rs` | 124 | `VisibilityMap` + `compute_fov`, `VisibilityState` (Hidden/Explored/Visible) |
 | `enemy.rs` | 180 | `Enemy` + FOV-aware BFS `step_toward_player`, `has_line_of_sight`, `patrol_step` |
@@ -22,7 +22,7 @@ All vim-rogue source. Tests in `tests/` (integration only).
 ## Where To Look
 | Task | File | What to change |
 |------|------|----------------|
-| Add Vim motion | `player.rs` + `types.rs` | VimMotion enum, handle_motion arm, game.rs parse_motion |
+| Add Vim motion | `player.rs` + `types.rs` | VimMotion enum, handle_motion arm on PlayerState, game.rs parse_motion |
 | Change dungeon | `map.rs` | carve_level, build_level_2/3/4, assign_zones |
 | Change UI | `renderer.rs` | Display only — never mutates state |
 | Change game flow | `game.rs` | handle_key, tick, pending_input for f/t/dd/gg; ESC/q opens pause |
@@ -30,7 +30,7 @@ All vim-rogue source. Tests in `tests/` (integration only).
 | Add shared type | `types.rs` | All modules `use crate::types::*` |
 | Change enemy AI | `enemy.rs` | step_toward_player (BFS), has_line_of_sight (Bresenham), patrol_step, called via World.enemies_step |
 | Change visibility | `visibility.rs` | compute_fov, VisibilityMap, demote_visible_to_explored |
-| Change aggregate logic | `types.rs` | World (terrain, visibility, enemies), PlayerState (position, HP, trail, progression), InputState (key buffering), Session (lifecycle, timing, pause) |
+| Change aggregate logic | `types.rs` + `player.rs` | World (terrain, visibility, enemies), PlayerState (position, motions, HP, trail, progression; impl in player.rs), InputState (key buffering), Session (lifecycle, timing, pause) |
 | Add animation | `animation.rs` | AnimationState + Interpolator; durations as constants |
 | Add sound | `audio.rs` | SoundEffect enum + AudioManager.play() |
 
@@ -51,9 +51,9 @@ lib.rs        ← main.rs (implicit)
 ## Conventions
 - `rustfmt.toml`: `use_small_heuristics = "Max"`, `edition = "2024"`. Run `cargo fmt --check` pre-commit.
 - `grid[y][x]` row-major — always bounds-check.
-- **Aggregates**: `App` is a thin coordinator (8 fields) delegating to 4 domain aggregates:
+- **Aggregates**: `App` is a thin coordinator delegating to 3 domain aggregates + PlayerState:
   - `World` — terrain, visibility, enemies, torchlights; owns `update_visibility`, `enemies_step`, `reset_for_level`
-  - `PlayerState` — position, HP, trail, motion tracking, level, checkpoint, pending respawn; owns motion/damage status messages
+  - `PlayerState` — flat struct (position, used_motions, last_direction, noclip, HP, trail, motion tracking, level, checkpoint, pending respawn); `impl PlayerState` in player.rs owns all motion logic + tracking (motion_count, discovered_motions)
   - `InputState` — `input_queue` + `pending_input` for two-phase Vim commands (f/t/dd/gg)
   - `Session` — game state, pause selection, timing, status message
 - Single-key motions fire immediately; f/t/dd/gg set `pending_input` via InputState for next key.
@@ -67,7 +67,7 @@ lib.rs        ← main.rs (implicit)
 - Audio: disabled default; `play()` no-ops when off.
 
 ## Tests
-393 integration tests in `tests/` (no inline tests in src/):
+396 integration tests in `tests/` (no inline tests in src/):
 | File | Tests | Coverage |
 |------|-------|----------|
 | `tests/game.rs` | 140 | Motions, pending input, animations, input queue, level transitions, enemies, audio, trail, visibility, win/loss/retry, pause, melee |
@@ -75,7 +75,7 @@ lib.rs        ← main.rs (implicit)
 | `tests/map.rs` | 46 | Dimensions, tiles, passability, zones, corridors, obstacles, 4 levels, reachability, spawns, patrol, torchlight |
 | `tests/animation.rs` | 34 | Timer progress, interpolation, easing, AnimationState, TestClock |
 | `tests/visibility.rs` | 29 | FOV center, wall blocking, radius, explored persistence, reset, corridors, symmetry, edge cases |
-| `tests/player.rs` | 29 | All 13 motions + boundaries + wall-stopping (w/b/G/gg) + recording |
+| `tests/player.rs` | 32 | All 13 motions + boundaries + wall-stopping (w/b/G/gg) + recording + motion_count + discovered_motions |
 | `tests/enemy.rs` | 21 | BFS movement, diagonal, walls, adjacency, corridors, shortest path, LOS, patrol |
 | `tests/types.rs` | 25 | Tile glyphs, motion labels/names/descriptions, zone titles, direction deltas, RenderGrid, ViewModel, Enemy |
 | `tests/audio.rs` | 16 | Lifecycle, play no-op, enable/disable, rapid play, variants |

--- a/src/game.rs
+++ b/src/game.rs
@@ -48,7 +48,7 @@ impl App {
     }
 
     pub fn current_zone(&self) -> crate::types::Zone {
-        self.world.map.zone_at(self.player.inner.position)
+        self.world.map.zone_at(self.player.position)
     }
 
     pub fn unique_motions(&self) -> usize {
@@ -56,7 +56,7 @@ impl App {
     }
 
     pub fn update_visibility(&mut self) {
-        self.world.update_visibility(self.player.inner.position);
+        self.world.update_visibility(self.player.position);
     }
 
     pub fn advance_level(&mut self) {
@@ -110,7 +110,7 @@ pub fn tick(app: &mut App, delta_ms: f64) {
                 Some(pos) => {
                     app.enemy_animations.clear();
                     app.player.hp = MAX_HP;
-                    app.player.inner.position = pos;
+                    app.player.position = pos;
                     app.player_animation = None;
                     app.session.game_state = GameState::Playing;
                     push_enemies_off_position(app, pos);
@@ -279,8 +279,8 @@ fn apply_cheat(app: &mut App, cheat: CheatCode) {
             app.session.status_message = String::from("CHEAT: All enemies eliminated!");
         }
         CheatCode::Noclip => {
-            app.player.inner.noclip = !app.player.inner.noclip;
-            app.session.status_message = if app.player.inner.noclip {
+            app.player.noclip = !app.player.noclip;
+            app.session.status_message = if app.player.noclip {
                 String::from("CHEAT: Noclip ON")
             } else {
                 String::from("CHEAT: Noclip OFF")
@@ -514,7 +514,7 @@ fn push_enemies_off_position(app: &mut App, pos: crate::types::Position) {
 }
 
 fn enemies_step(app: &mut App) {
-    let player_pos = app.player.inner.position;
+    let player_pos = app.player.position;
     let mut prior_animations = vec![None; app.world.enemies.len()];
     for (enemy_index, animation) in std::mem::take(&mut app.enemy_animations) {
         if enemy_index < prior_animations.len() {
@@ -550,7 +550,7 @@ fn enemies_step(app: &mut App) {
         }
     }
 
-    let player_pos = app.player.inner.position;
+    let player_pos = app.player.position;
     let invincible = app.is_invincible();
     let mut remaining_enemies = Vec::with_capacity(app.world.enemies.len());
     let mut next_animations = Vec::new();
@@ -619,30 +619,28 @@ fn enemies_step(app: &mut App) {
 }
 
 fn execute_motion(app: &mut App, motion: VimMotion, target: Option<char>) {
-    let old_pos = app.player.inner.position;
+    let old_pos = app.player.position;
     let old_zone = app.world.map.zone_at(old_pos);
 
     let activated = {
         app.session.status_message = app.player.motion_feedback(motion, target);
-        app.player.inner.handle_motion(motion, target, &mut app.world.map)
+        app.player.handle_motion(motion, target, &mut app.world.map)
     };
 
-    app.player.motion_count += 1;
-    app.player.discovered_motions.insert(motion);
     app.refresh_time();
 
-    if activated && old_pos != app.player.inner.position {
+    if activated && old_pos != app.player.position {
         app.player_animation = Some(AnimationState::new(
             PLAYER_MOVE_MS,
             (old_pos.x as f64, old_pos.y as f64),
-            (app.player.inner.position.x as f64, app.player.inner.position.y as f64),
+            (app.player.position.x as f64, app.player.position.y as f64),
         ));
         app.player.trail.push_front(old_pos);
         if app.player.trail.len() > crate::types::TRAIL_MAX {
             app.player.trail.pop_back();
         }
         app.audio.play(SoundEffect::Movement);
-        let new_zone = app.world.map.zone_at(app.player.inner.position);
+        let new_zone = app.world.map.zone_at(app.player.position);
         if new_zone != old_zone {
             app.audio.play(SoundEffect::ZoneEntry);
         }
@@ -652,10 +650,8 @@ fn execute_motion(app: &mut App, motion: VimMotion, target: Option<char>) {
         app.session.status_message.push_str(" No valid destination from here.");
     }
 
-    if app.world.map.get_tile(app.player.inner.position.x, app.player.inner.position.y)
-        == Tile::Torchlight
-    {
-        let torch_pos = app.player.inner.position;
+    if app.world.map.get_tile(app.player.position.x, app.player.position.y) == Tile::Torchlight {
+        let torch_pos = app.player.position;
         if !app.world.activated_torchlights.contains(&torch_pos) {
             app.world.activated_torchlights.insert(torch_pos);
             app.player.last_checkpoint = Some(torch_pos);
@@ -663,9 +659,7 @@ fn execute_motion(app: &mut App, motion: VimMotion, target: Option<char>) {
         }
     }
 
-    if app.world.map.get_tile(app.player.inner.position.x, app.player.inner.position.y)
-        == Tile::Exit
-    {
+    if app.world.map.get_tile(app.player.position.x, app.player.position.y) == Tile::Exit {
         if app.player.level < crate::types::TOTAL_LEVELS {
             app.audio.play(SoundEffect::LevelComplete);
             app.advance_level();
@@ -680,14 +674,14 @@ fn execute_motion(app: &mut App, motion: VimMotion, target: Option<char>) {
         return;
     }
 
-    if activated && old_pos != app.player.inner.position {
+    if activated && old_pos != app.player.position {
         app.update_visibility();
         enemies_step(app);
     }
 }
 
 fn handle_melee_attack(app: &mut App) {
-    let facing = match app.player.inner.last_direction {
+    let facing = match app.player.last_direction {
         Some(dir) => dir,
         None => {
             app.session.status_message = String::from("No direction — move first.");
@@ -696,8 +690,8 @@ fn handle_melee_attack(app: &mut App) {
     };
 
     let (dx, dy) = facing.delta();
-    let target_x = (app.player.inner.position.x as isize + dx) as usize;
-    let target_y = (app.player.inner.position.y as isize + dy) as usize;
+    let target_x = (app.player.position.x as isize + dx) as usize;
+    let target_y = (app.player.position.y as isize + dy) as usize;
 
     let enemy_index =
         app.world.enemies.iter().position(|e| e.position.x == target_x && e.position.y == target_y);

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,27 +1,7 @@
-use std::collections::HashSet;
-
 use crate::map::Map;
-use crate::types::{Direction, Position, Tile, VimMotion};
+use crate::types::{Direction, PlayerState, Position, Tile, VimMotion};
 
-pub struct Player {
-    pub position: Position,
-    pub used_motions: HashSet<VimMotion>,
-    pub last_direction: Option<Direction>,
-    #[cfg(debug_assertions)]
-    pub noclip: bool,
-}
-
-impl Player {
-    pub fn new(position: Position) -> Self {
-        Self {
-            position,
-            used_motions: HashSet::new(),
-            last_direction: None,
-            #[cfg(debug_assertions)]
-            noclip: false,
-        }
-    }
-
+impl PlayerState {
     pub fn can_pass_to(&self, x: usize, y: usize, map: &Map) -> bool {
         #[cfg(debug_assertions)]
         if self.noclip {
@@ -37,6 +17,8 @@ impl Player {
         map: &mut Map,
     ) -> bool {
         self.used_motions.insert(motion);
+        self.motion_count += 1;
+        self.discovered_motions.insert(motion);
         let old_pos = self.position;
 
         let activated = match motion {
@@ -55,7 +37,6 @@ impl Player {
             VimMotion::GotoLine => self.jump_to_column_top(map),
         };
 
-        // Update facing based on net displacement
         if activated && self.position != old_pos {
             let dx = self.position.x as isize - old_pos.x as isize;
             let dy = self.position.y as isize - old_pos.y as isize;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -199,7 +199,7 @@ pub fn visual_player_position(app: &App) -> Position {
     let (x, y) = app
         .player_animation
         .map(|animation| animation.current_position())
-        .unwrap_or((app.player.inner.position.x as f64, app.player.inner.position.y as f64));
+        .unwrap_or((app.player.position.x as f64, app.player.position.y as f64));
 
     Position {
         x: x.round().clamp(0.0, app.world.map.width.saturating_sub(1) as f64) as usize,
@@ -312,7 +312,7 @@ fn render_sidebar(ctx: &mut BTerm, app: &App, sidebar_x: i32) {
             if y >= 47 {
                 break;
             }
-            let used = app.player.inner.used_motions.contains(motion);
+            let used = app.player.used_motions.contains(motion);
             let marker = if used { "✓" } else { "·" };
             let color = if used { green } else { dark_gray };
             let label = format!("{} {:<7} {}", marker, motion.key_label(), motion.display_name());
@@ -434,7 +434,7 @@ fn render_minimap(ctx: &mut BTerm, app: &App, x: i32, start_y: i32, y_out: &mut 
         }
     }
 
-    let (px, py) = minimap_player_pos(app.player.inner.position.x, app.player.inner.position.y);
+    let (px, py) = minimap_player_pos(app.player.position.x, app.player.position.y);
     ctx.print_color(x + 1 + px, mm_y + 1 + py, RGB::named(GREEN), black, "@");
 
     *y_out = bottom_y + 1;

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,7 +8,6 @@ use bracket_lib::prelude::VirtualKeyCode;
 use crate::animation::{AnimationState, AttackEffect};
 use crate::audio::AudioManager;
 use crate::map::Map;
-use crate::player::Player;
 use crate::visibility::VisibilityMap;
 
 pub const TRAIL_MAX: usize = 8;
@@ -438,7 +437,11 @@ impl World {
 }
 
 pub struct PlayerState {
-    pub inner: Player,
+    pub position: Position,
+    pub used_motions: HashSet<VimMotion>,
+    pub last_direction: Option<Direction>,
+    #[cfg(debug_assertions)]
+    pub noclip: bool,
     pub hp: i32,
     pub trail: VecDeque<Position>,
     pub motion_count: usize,
@@ -451,7 +454,11 @@ pub struct PlayerState {
 impl PlayerState {
     pub fn new(position: Position) -> Self {
         Self {
-            inner: Player::new(position),
+            position,
+            used_motions: HashSet::new(),
+            last_direction: None,
+            #[cfg(debug_assertions)]
+            noclip: false,
             hp: MAX_HP,
             trail: VecDeque::new(),
             motion_count: 0,
@@ -464,14 +471,14 @@ impl PlayerState {
 
     pub fn advance_level(&mut self, level: usize, start: Position) {
         self.level = level;
-        self.inner.position = start;
+        self.position = start;
         self.trail.clear();
         self.last_checkpoint = None;
         self.pending_respawn = None;
     }
 
     pub fn retry_level(&mut self, start: Position) {
-        self.inner.position = start;
+        self.position = start;
         self.hp = MAX_HP;
         self.trail.clear();
         self.last_checkpoint = None;

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -2,7 +2,7 @@
 
 # tests
 
-393 integration tests, 9 files. No inline tests in src/. Shared helpers in `tests/common/mod.rs`.
+396 integration tests, 9 files. No inline tests in src/. Shared helpers in `tests/common/mod.rs`.
 
 ## Test Files
 | File | Tests | Lines | Coverage |
@@ -11,7 +11,7 @@
 | `map.rs` | 46 | 539 | Dimensions, tiles, passability, zones, corridors, obstacles, 4 levels, reachability, enemy spawns, patrol areas, torchlight room presence |
 | `renderer.rs` | 53 | 428 | Zone colors, wall glyphs, duration formatting, phases, exit glow, trail colors, minimap, fog, centering |
 | `visibility.rs` | 29 | 420 | FOV center, wall blocking, radius, explored persistence, reset, corridors, symmetry, edge cases, multi-source FOV |
-| `player.rs` | 29 | 324 | All 13 motions + boundaries + wall-stopping (w/b/G/gg) + motion recording |
+| `player.rs` | 32 | 371 | All 13 motions + boundaries + wall-stopping (w/b/G/gg) + motion recording + motion_count + discovered_motions |
 | `animation.rs` | 34 | 349 | Timer progress, interpolation, easing, AnimationState, TestClock determinism, attack effects |
 | `types.rs` | 25 | 216 | Tile glyphs, motion labels/names/descriptions, zone titles, direction deltas, RenderGrid, ViewModel, Enemy |
 | `enemy.rs` | 21 | 265 | BFS movement, diagonal, walls, adjacency, corridors, shortest path, LOS, patrol |
@@ -38,7 +38,7 @@
 
 ## Conventions
 - Test file mirrors src/ module (`tests/player.rs` ↔ `src/player.rs`).
-- `handle_key(app, VirtualKeyCode, shift: bool)` = main input entry for game tests. Access aggregates via `app.world`, `app.player_state`, `app.input_state`, `app.session`.
+- `handle_key(app, VirtualKeyCode, shift: bool)` = main input entry for game tests. Access aggregates via `app.world`, `app.player`, `app.input`, `app.session`.
 - `tick(&mut app, delta_ms: f64)` advances clock, processes one frame.
 - Animation constants: `PLAYER_MOVE_MS = 150.0`, `ENEMY_MOVE_MS = 200.0`, `ATTACK_EFFECT_MS = 200.0` — import from `vim_rogue::animation`.
 - `TestClock` = deterministic timing. Always use in tests, never `RealClock`.

--- a/tests/game.rs
+++ b/tests/game.rs
@@ -65,7 +65,7 @@ fn app_new_has_visibility_map() {
 
     assert_eq!(app.world.visibility.width(), 80);
     assert_eq!(app.world.visibility.height(), 40);
-    assert_eq!(app.world.visibility.get(app.player.inner.position), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(app.player.position), VisibilityState::Visible);
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn update_visibility_makes_area_visible() {
     app.world.visibility.reset();
     app.update_visibility();
 
-    assert_eq!(app.world.visibility.get(app.player.inner.position), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(app.player.position), VisibilityState::Visible);
     assert_eq!(app.world.visibility.get(Position { x: 3, y: 2 }), VisibilityState::Visible);
 }
 
@@ -155,7 +155,7 @@ fn app_h_motion_moves_player() {
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert_eq!(app.player.inner.position, Position { x: 1, y: 0 });
+    assert_eq!(app.player.position, Position { x: 1, y: 0 });
 }
 
 #[test]
@@ -217,7 +217,7 @@ fn input_queued_during_animation() {
     handle_key(&mut app, VirtualKeyCode::L, false);
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.player.inner.position, Position { x: 2, y: 0 });
+    assert_eq!(app.player.position, Position { x: 2, y: 0 });
     assert_eq!(app.input.input_queue, vec![(VirtualKeyCode::L, false)]);
 }
 
@@ -230,7 +230,7 @@ fn queued_input_executed_after_animation() {
     tick(&mut app, PLAYER_MOVE_MS);
 
     let animation = app.player_animation.expect("queued move should start a new animation");
-    assert_eq!(app.player.inner.position, Position { x: 3, y: 0 });
+    assert_eq!(app.player.position, Position { x: 3, y: 0 });
     assert!(app.input.input_queue.is_empty());
     assert_eq!((animation.start_x, animation.start_y), (2.0, 0.0));
     assert_eq!((animation.end_x, animation.end_y), (3.0, 0.0));
@@ -245,7 +245,7 @@ fn queued_multi_key_motion_executes_without_stalling() {
     handle_key(&mut app, VirtualKeyCode::G, false);
     tick(&mut app, PLAYER_MOVE_MS);
 
-    assert_eq!(app.player.inner.position, Position { x: 3, y: 0 });
+    assert_eq!(app.player.position, Position { x: 3, y: 0 });
     assert_eq!(app.input.pending_input, None);
     assert!(app.player_animation.is_some());
     assert!(app.input.input_queue.is_empty());
@@ -270,7 +270,7 @@ fn queued_find_preserves_pending_input_after_animation() {
     handle_key(&mut app, VirtualKeyCode::Period, true);
 
     assert_eq!(app.input.pending_input, None);
-    assert_eq!(app.player.inner.position, Position { x: 4, y: 0 });
+    assert_eq!(app.player.position, Position { x: 4, y: 0 });
 }
 
 #[test]
@@ -289,7 +289,7 @@ fn queued_till_preserves_pending_input_after_animation() {
     handle_key(&mut app, VirtualKeyCode::Period, true);
 
     assert_eq!(app.input.pending_input, None);
-    assert_eq!(app.player.inner.position, Position { x: 4, y: 0 });
+    assert_eq!(app.player.position, Position { x: 4, y: 0 });
 }
 
 #[test]
@@ -325,7 +325,7 @@ fn queued_goto_line_preserves_pending_input_after_animation() {
     handle_key(&mut app, VirtualKeyCode::G, false);
 
     assert_eq!(app.input.pending_input, None);
-    assert_eq!(app.player.inner.position.y, 0);
+    assert_eq!(app.player.position.y, 0);
 }
 
 #[test]
@@ -341,7 +341,7 @@ fn rapid_keypresses_preserve_order_without_double_triggering() {
     tick(&mut app, PLAYER_MOVE_MS);
     tick(&mut app, PLAYER_MOVE_MS);
 
-    assert_eq!(app.player.inner.position, Position { x: 3, y: 0 });
+    assert_eq!(app.player.position, Position { x: 3, y: 0 });
     assert_eq!(app.player.motion_count, 4);
     assert!(app.input.input_queue.is_empty());
     assert!(app.player_animation.is_some());
@@ -362,7 +362,7 @@ fn rapid_keypresses_can_queue_find_and_target_together() {
     tick(&mut app, PLAYER_MOVE_MS);
 
     assert_eq!(app.input.pending_input, None);
-    assert_eq!(app.player.inner.position, Position { x: 4, y: 0 });
+    assert_eq!(app.player.position, Position { x: 4, y: 0 });
     assert!(app.input.input_queue.is_empty());
 }
 
@@ -421,7 +421,7 @@ fn app_f_then_char_finds() {
     handle_key(&mut app, VirtualKeyCode::F, false);
     handle_key(&mut app, VirtualKeyCode::Period, true);
 
-    assert_eq!(app.player.inner.position, Position { x: 4, y: 0 });
+    assert_eq!(app.player.position, Position { x: 4, y: 0 });
 }
 
 #[test]
@@ -538,7 +538,7 @@ fn app_level_transition_resets_player_position() {
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.player.inner.position, app.world.map.start);
+    assert_eq!(app.player.position, app.world.map.start);
 }
 
 #[test]
@@ -552,7 +552,7 @@ fn app_level_transition_loads_new_map() {
     handle_key(&mut app, VirtualKeyCode::L, false);
 
     assert_eq!(app.player.level, 2);
-    assert_eq!(app.player.inner.position, app.world.map.start);
+    assert_eq!(app.player.position, app.world.map.start);
 }
 
 #[test]
@@ -561,7 +561,7 @@ fn app_g_jump_to_column_bottom() {
 
     handle_key(&mut app, VirtualKeyCode::G, true);
 
-    assert_eq!(app.player.inner.position, Position { x: 2, y: 4 });
+    assert_eq!(app.player.position, Position { x: 2, y: 4 });
     assert_eq!(app.input.pending_input, None);
 }
 
@@ -574,7 +574,7 @@ fn app_gg_two_keys_jump_to_column_top() {
 
     handle_key(&mut app, VirtualKeyCode::G, false);
 
-    assert_eq!(app.player.inner.position, Position { x: 2, y: 0 });
+    assert_eq!(app.player.position, Position { x: 2, y: 0 });
     assert_eq!(app.input.pending_input, None);
 }
 
@@ -585,7 +585,7 @@ fn app_g_then_other_cancels() {
     handle_key(&mut app, VirtualKeyCode::G, false);
     handle_key(&mut app, VirtualKeyCode::X, false);
 
-    assert_eq!(app.player.inner.position, Position { x: 2, y: 2 });
+    assert_eq!(app.player.position, Position { x: 2, y: 2 });
     assert_eq!(app.input.pending_input, None);
     assert!(app.session.status_message.contains("cancelled"));
 }
@@ -600,7 +600,7 @@ fn app_lost_state_any_key_restarts_level() {
     handle_key(&mut app, VirtualKeyCode::H, false);
 
     assert_eq!(app.session.game_state, GameState::Playing);
-    assert_eq!(app.player.inner.position, app.world.map.start);
+    assert_eq!(app.player.position, app.world.map.start);
     assert!(app.player.trail.is_empty());
     assert_eq!(app.player.level, 2);
 }
@@ -615,7 +615,7 @@ fn advance_level_resets_visibility() {
     app.advance_level();
 
     assert_eq!(app.world.visibility.get(far_tile), VisibilityState::Hidden);
-    assert_eq!(app.world.visibility.get(app.player.inner.position), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(app.player.position), VisibilityState::Visible);
 }
 
 #[test]
@@ -628,7 +628,7 @@ fn retry_level_resets_visibility() {
     app.retry_level();
 
     assert_eq!(app.world.visibility.get(far_tile), VisibilityState::Hidden);
-    assert_eq!(app.world.visibility.get(app.player.inner.position), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(app.player.position), VisibilityState::Visible);
 }
 
 #[test]
@@ -798,7 +798,7 @@ fn audio_movement_plays_on_successful_move() {
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_ne!(app.player.inner.position, Position { x: 2, y: 0 });
+    assert_ne!(app.player.position, Position { x: 2, y: 0 });
 }
 
 #[test]
@@ -808,7 +808,7 @@ fn audio_no_sound_on_failed_move() {
 
     handle_key(&mut app, VirtualKeyCode::H, false);
 
-    assert_eq!(app.player.inner.position, Position { x: 0, y: 0 });
+    assert_eq!(app.player.position, Position { x: 0, y: 0 });
 }
 
 #[test]
@@ -825,7 +825,7 @@ fn audio_zone_entry_plays_on_zone_change() {
 
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.player.inner.position, Position { x: 16, y: 0 });
+    assert_eq!(app.player.position, Position { x: 16, y: 0 });
 }
 
 #[test]
@@ -836,7 +836,7 @@ fn audio_no_zone_entry_sound_when_same_zone() {
     handle_key(&mut app, VirtualKeyCode::L, false);
 
     assert_eq!(
-        app.world.map.zone_at(app.player.inner.position),
+        app.world.map.zone_at(app.player.position),
         app.world.map.zone_at(Position { x: 2, y: 0 })
     );
 }
@@ -1022,7 +1022,7 @@ fn visibility_updates_after_each_move() {
     handle_key(&mut app, VirtualKeyCode::L, false);
 
     assert_eq!(app.world.visibility.get(Position { x: 6, y: 10 }), VisibilityState::Visible);
-    assert_eq!(app.world.visibility.get(app.player.inner.position), VisibilityState::Visible);
+    assert_eq!(app.world.visibility.get(app.player.position), VisibilityState::Visible);
 }
 
 #[test]
@@ -1034,7 +1034,7 @@ fn audio_enabled_does_not_crash_during_movement() {
     handle_key(&mut app, VirtualKeyCode::H, false);
     handle_key(&mut app, VirtualKeyCode::L, false);
 
-    assert_eq!(app.player.inner.position, Position { x: 3, y: 0 });
+    assert_eq!(app.player.position, Position { x: 3, y: 0 });
 }
 
 fn level4_app_with_enemy(enemy_pos: Position, enemy_hp: Option<i32>) -> App {
@@ -1042,45 +1042,45 @@ fn level4_app_with_enemy(enemy_pos: Position, enemy_hp: Option<i32>) -> App {
     let mut app = started_app_with_map(map, Position { x: 5, y: 5 });
     app.player.level = 4;
     app.world.enemies = vec![Enemy { position: enemy_pos, hp: enemy_hp, ..Enemy::new(enemy_pos) }];
-    app.player.inner.last_direction = Some(Direction::Right);
+    app.player.last_direction = Some(Direction::Right);
     app
 }
 
 #[test]
 fn facing_updates_on_l_movement() {
     let mut app = started_app_with_map(test_map(5, 1), Position { x: 2, y: 0 });
-    assert_eq!(app.player.inner.last_direction, None);
+    assert_eq!(app.player.last_direction, None);
     handle_key(&mut app, VirtualKeyCode::L, false);
-    assert_eq!(app.player.inner.last_direction, Some(Direction::Right));
+    assert_eq!(app.player.last_direction, Some(Direction::Right));
 }
 
 #[test]
 fn facing_updates_on_h_movement() {
     let mut app = started_app_with_map(test_map(5, 1), Position { x: 2, y: 0 });
     handle_key(&mut app, VirtualKeyCode::H, false);
-    assert_eq!(app.player.inner.last_direction, Some(Direction::Left));
+    assert_eq!(app.player.last_direction, Some(Direction::Left));
 }
 
 #[test]
 fn facing_updates_on_j_movement() {
     let mut app = started_app_with_map(test_map(5, 5), Position { x: 2, y: 2 });
     handle_key(&mut app, VirtualKeyCode::J, false);
-    assert_eq!(app.player.inner.last_direction, Some(Direction::Down));
+    assert_eq!(app.player.last_direction, Some(Direction::Down));
 }
 
 #[test]
 fn facing_updates_on_k_movement() {
     let mut app = started_app_with_map(test_map(5, 5), Position { x: 2, y: 2 });
     handle_key(&mut app, VirtualKeyCode::K, false);
-    assert_eq!(app.player.inner.last_direction, Some(Direction::Up));
+    assert_eq!(app.player.last_direction, Some(Direction::Up));
 }
 
 #[test]
 fn facing_does_not_update_on_failed_move() {
     let mut app = started_app_with_map(test_map(5, 1), Position { x: 0, y: 0 });
-    assert_eq!(app.player.inner.last_direction, None);
+    assert_eq!(app.player.last_direction, None);
     handle_key(&mut app, VirtualKeyCode::H, false);
-    assert_eq!(app.player.inner.last_direction, None);
+    assert_eq!(app.player.last_direction, None);
 }
 
 #[test]
@@ -1106,7 +1106,7 @@ fn melee_attack_kills_enemy_after_3_hits() {
         hp: Some(20),
         ..Enemy::new(Position { x: 6, y: 5 })
     }];
-    app.player.inner.last_direction = Some(Direction::Right);
+    app.player.last_direction = Some(Direction::Right);
 
     handle_key(&mut app, VirtualKeyCode::X, false);
     assert!(app.session.status_message.contains("Hit"));
@@ -1117,7 +1117,7 @@ fn melee_attack_kills_enemy_after_3_hits() {
         hp: Some(10),
         ..Enemy::new(Position { x: 6, y: 5 })
     }];
-    app.player.inner.last_direction = Some(Direction::Right);
+    app.player.last_direction = Some(Direction::Right);
 
     handle_key(&mut app, VirtualKeyCode::X, false);
     assert!(app.session.status_message.contains("defeated"));
@@ -1145,7 +1145,7 @@ fn melee_attack_noop_on_level_1_non_hp_enemy() {
 #[test]
 fn melee_attack_no_facing() {
     let mut app = level4_app_with_enemy(Position { x: 6, y: 5 }, Some(30));
-    app.player.inner.last_direction = None;
+    app.player.last_direction = None;
     let initial_motions = app.player.motion_count;
     handle_key(&mut app, VirtualKeyCode::X, false);
     assert!(
@@ -1208,7 +1208,7 @@ fn stunned_enemy_does_not_deal_damage() {
         stunned_turns: 1,
         ..Enemy::new(Position { x: 4, y: 5 })
     }];
-    app.player.inner.last_direction = Some(Direction::Right);
+    app.player.last_direction = Some(Direction::Right);
 
     // Player moves right to (6,5) — enemies_step runs, stunned enemy stays put
     handle_key(&mut app, VirtualKeyCode::L, false);
@@ -1232,7 +1232,7 @@ fn stun_wears_off_after_one_turn() {
         stunned_turns: 1,
         ..Enemy::new(Position { x: 6, y: 5 })
     }];
-    app.player.inner.last_direction = Some(Direction::Right);
+    app.player.last_direction = Some(Direction::Right);
 
     // Turn 1: enemy is stunned, stun decrements to 0
     handle_key(&mut app, VirtualKeyCode::X, false);
@@ -1258,7 +1258,7 @@ fn stun_prevents_enemy_counterattack_after_melee() {
     let mut app = started_app_with_map(map, Position { x: 5, y: 5 });
     app.player.level = 4;
     app.player.hp = 10;
-    app.player.inner.last_direction = Some(Direction::Right);
+    app.player.last_direction = Some(Direction::Right);
     app.world.enemies = vec![Enemy {
         position: Position { x: 6, y: 5 },
         hp: Some(20),
@@ -1298,7 +1298,7 @@ fn death_with_checkpoint_respawns_at_torchlight() {
     tick(&mut app, 0.0);
     assert_eq!(app.player.hp, MAX_HP, "HP should be restored to MAX_HP after checkpoint respawn");
     assert_eq!(
-        app.player.inner.position,
+        app.player.position,
         Position { x: 10, y: 10 },
         "Player should respawn at checkpoint"
     );
@@ -1395,7 +1395,7 @@ fn enemy_on_checkpoint_tile_is_pushed_on_respawn() {
     tick(&mut app, ATTACK_EFFECT_MS);
     tick(&mut app, 0.0);
     assert_eq!(app.session.game_state, GameState::Playing);
-    assert_eq!(app.player.inner.position, checkpoint, "Player should be at checkpoint");
+    assert_eq!(app.player.position, checkpoint, "Player should be at checkpoint");
     let enemy_on_checkpoint = app.world.enemies.iter().any(|e| e.position == checkpoint);
     assert!(!enemy_on_checkpoint, "Enemy should be pushed off checkpoint tile");
     assert_eq!(app.world.enemies.len(), 1, "One surviving enemy after respawn");
@@ -1487,7 +1487,7 @@ fn level_4_colliding_enemy_persists_on_checkpoint_respawn() {
     let checkpoint = Position { x: 10, y: 10 };
     app.player.last_checkpoint = Some(checkpoint);
     app.world.activated_torchlights.insert(checkpoint);
-    app.player.inner.last_direction = Some(Direction::Right);
+    app.player.last_direction = Some(Direction::Right);
     // Level 4 enemy with hp: Some(30)
     app.world.enemies = vec![Enemy {
         position: Position { x: 6, y: 5 },
@@ -1504,7 +1504,7 @@ fn level_4_colliding_enemy_persists_on_checkpoint_respawn() {
 
     // Player should have respawned at checkpoint
     assert_eq!(app.player.hp, MAX_HP, "HP should be restored to MAX_HP");
-    assert_eq!(app.player.inner.position, checkpoint, "Player should respawn at checkpoint");
+    assert_eq!(app.player.position, checkpoint, "Player should respawn at checkpoint");
     assert_eq!(app.session.game_state, GameState::Playing, "Should be Playing after respawn");
 
     // The Level 4 enemy should persist (not despawn)
@@ -1617,7 +1617,7 @@ fn checkpoint_respawn_preserves_hit_effect() {
     let checkpoint = Position { x: 10, y: 10 };
     app.player.last_checkpoint = Some(checkpoint);
     app.world.activated_torchlights.insert(checkpoint);
-    app.player.inner.last_direction = Some(Direction::Right);
+    app.player.last_direction = Some(Direction::Right);
     app.world.enemies = vec![Enemy {
         position: Position { x: 6, y: 5 },
         hp: Some(30),
@@ -1629,7 +1629,7 @@ fn checkpoint_respawn_preserves_hit_effect() {
     tick(&mut app, ATTACK_EFFECT_MS);
     tick(&mut app, 0.0);
     assert_eq!(app.session.game_state, GameState::Playing);
-    assert_eq!(app.player.inner.position, checkpoint);
+    assert_eq!(app.player.position, checkpoint);
 }
 
 #[test]
@@ -1695,9 +1695,9 @@ fn dying_state_ignores_input() {
     app.world.enemies.push(Enemy::new(Position { x: 1, y: 0 }));
     handle_key(&mut app, VirtualKeyCode::H, false);
     assert_eq!(app.session.game_state, GameState::Dying);
-    let pos_before = app.player.inner.position;
+    let pos_before = app.player.position;
     handle_key(&mut app, VirtualKeyCode::L, false);
-    assert_eq!(app.player.inner.position, pos_before, "input should be ignored during Dying");
+    assert_eq!(app.player.position, pos_before, "input should be ignored during Dying");
 }
 
 #[test]
@@ -1728,7 +1728,7 @@ fn two_enemies_same_turn_both_hit_at_high_hp() {
     app.world.enemies.push(Enemy::new(Position { x: 4, y: 0 }));
     app.world.enemies.push(Enemy::new(Position { x: 4, y: 2 }));
     handle_key(&mut app, VirtualKeyCode::H, false);
-    assert_eq!(app.player.inner.position, Position { x: 4, y: 1 });
+    assert_eq!(app.player.position, Position { x: 4, y: 1 });
     assert_eq!(app.player.hp, 0);
     assert_eq!(app.session.game_state, GameState::Dying);
     assert_eq!(app.attack_effects.len(), 2);
@@ -1756,18 +1756,18 @@ fn checkpoint_respawn_pushes_stacked_enemies_off_checkpoint() {
     app.player.hp = 10;
     app.player.last_checkpoint = Some(checkpoint);
     app.world.activated_torchlights.insert(checkpoint);
-    app.player.inner.last_direction = Some(Direction::Up);
+    app.player.last_direction = Some(Direction::Up);
     app.world.enemies = vec![
         Enemy { position: checkpoint, hp: Some(30), ..Enemy::new(checkpoint) },
         Enemy { position: checkpoint, hp: Some(30), ..Enemy::new(checkpoint) },
     ];
     handle_key(&mut app, VirtualKeyCode::K, false);
-    assert_eq!(app.player.inner.position, Position { x: 5, y: 5 });
+    assert_eq!(app.player.position, Position { x: 5, y: 5 });
     assert_eq!(app.session.game_state, GameState::Dying);
     tick(&mut app, ATTACK_EFFECT_MS);
     tick(&mut app, 0.0);
     assert_eq!(app.session.game_state, GameState::Playing);
-    assert_eq!(app.player.inner.position, checkpoint);
+    assert_eq!(app.player.position, checkpoint);
     assert_eq!(app.world.enemies.len(), 2);
     let on_checkpoint = app.world.enemies.iter().any(|e| e.position == checkpoint);
     assert!(!on_checkpoint, "no enemy should remain on checkpoint tile");
@@ -1799,7 +1799,7 @@ fn push_enemies_bfs_respects_walls() {
     tick(&mut app, ATTACK_EFFECT_MS);
     tick(&mut app, 0.0);
     assert_eq!(app.session.game_state, GameState::Playing);
-    assert_eq!(app.player.inner.position, checkpoint);
+    assert_eq!(app.player.position, checkpoint);
     assert_eq!(app.world.enemies.len(), 2);
     // Enemies stay at checkpoint since all neighbors are impassable walls
     assert!(
@@ -1980,14 +1980,14 @@ fn cheat_ie_kills_all_enemies() {
 #[cfg(debug_assertions)]
 fn cheat_ip_toggles_noclip() {
     let mut app = started_app_with_map(test_map(10, 10), Position { x: 5, y: 5 });
-    assert!(!app.player.inner.noclip);
+    assert!(!app.player.noclip);
     handle_key(&mut app, VirtualKeyCode::I, false);
     handle_key(&mut app, VirtualKeyCode::P, false);
-    assert!(app.player.inner.noclip);
+    assert!(app.player.noclip);
     assert!(app.session.status_message.contains("Noclip ON"));
     handle_key(&mut app, VirtualKeyCode::I, false);
     handle_key(&mut app, VirtualKeyCode::P, false);
-    assert!(!app.player.inner.noclip);
+    assert!(!app.player.noclip);
     assert!(app.session.status_message.contains("Noclip OFF"));
 }
 
@@ -1998,11 +1998,11 @@ fn cheat_noclip_allows_wall_walking() {
     map.set_tile(6, 5, Tile::Wall);
     let mut app = started_app_with_map(map, Position { x: 5, y: 5 });
     handle_key(&mut app, VirtualKeyCode::L, false);
-    assert_eq!(app.player.inner.position, Position { x: 5, y: 5 });
+    assert_eq!(app.player.position, Position { x: 5, y: 5 });
     handle_key(&mut app, VirtualKeyCode::I, false);
     handle_key(&mut app, VirtualKeyCode::P, false);
     handle_key(&mut app, VirtualKeyCode::L, false);
-    assert_eq!(app.player.inner.position, Position { x: 6, y: 5 });
+    assert_eq!(app.player.position, Position { x: 6, y: 5 });
 }
 
 #[test]

--- a/tests/player.rs
+++ b/tests/player.rs
@@ -321,3 +321,50 @@ fn player_handle_motion_records_in_used_motions() {
         assert!(player.used_motions.contains(&motion));
     }
 }
+
+#[test]
+fn handle_motion_increments_motion_count_on_success_and_failure() {
+    let mut map = test_map(5, 5);
+    let mut player = PlayerState::new(Position { x: 0, y: 0 });
+
+    assert_eq!(player.motion_count, 0);
+
+    // Failed motion still increments count
+    assert!(!player.handle_motion(VimMotion::GotoLine, None, &mut map));
+    assert_eq!(player.motion_count, 1);
+
+    // Successful motion increments count
+    assert!(player.handle_motion(VimMotion::L, None, &mut map));
+    assert_eq!(player.motion_count, 2);
+}
+
+#[test]
+fn handle_motion_discovered_motions_no_duplicates() {
+    let mut map = test_map(5, 5);
+    let mut player = PlayerState::new(Position { x: 0, y: 0 });
+
+    assert!(player.discovered_motions.is_empty());
+
+    // First call registers motion
+    player.handle_motion(VimMotion::L, None, &mut map);
+    assert!(player.discovered_motions.contains(&VimMotion::L));
+    assert_eq!(player.discovered_motions.len(), 1);
+
+    // Repeated call does not add duplicate
+    player.handle_motion(VimMotion::L, None, &mut map);
+    assert_eq!(player.discovered_motions.len(), 1);
+
+    // Different motion adds to set
+    player.handle_motion(VimMotion::J, None, &mut map);
+    assert_eq!(player.discovered_motions.len(), 2);
+}
+
+#[test]
+fn handle_motion_discovered_motions_includes_failed_attempts() {
+    let mut map = test_map(5, 5);
+    let mut player = PlayerState::new(Position { x: 0, y: 0 });
+
+    // GotoLine fails at y=0 but still registers
+    assert!(!player.handle_motion(VimMotion::GotoLine, None, &mut map));
+    assert!(player.discovered_motions.contains(&VimMotion::GotoLine));
+}

--- a/tests/player.rs
+++ b/tests/player.rs
@@ -2,19 +2,18 @@ mod common;
 
 use common::test_map;
 use vim_rogue::map::Map;
-use vim_rogue::player::Player;
-use vim_rogue::types::{Position, Tile, VimMotion, Zone};
+use vim_rogue::types::{PlayerState, Position, Tile, VimMotion, Zone};
 
 #[test]
 fn player_new_has_starting_position() {
-    let player = Player::new(Position { x: 2, y: 3 });
+    let player = PlayerState::new(Position { x: 2, y: 3 });
 
     assert_eq!(player.position, Position { x: 2, y: 3 });
 }
 
 #[test]
 fn player_new_has_empty_used_motions() {
-    let player = Player::new(Position { x: 2, y: 3 });
+    let player = PlayerState::new(Position { x: 2, y: 3 });
 
     assert!(player.used_motions.is_empty());
 }
@@ -22,7 +21,7 @@ fn player_new_has_empty_used_motions() {
 #[test]
 fn player_step_right() {
     let mut map = test_map(5, 5);
-    let mut player = Player::new(Position { x: 1, y: 1 });
+    let mut player = PlayerState::new(Position { x: 1, y: 1 });
 
     assert!(player.handle_motion(VimMotion::L, None, &mut map));
     assert_eq!(player.position, Position { x: 2, y: 1 });
@@ -31,7 +30,7 @@ fn player_step_right() {
 #[test]
 fn player_step_left() {
     let mut map = test_map(5, 5);
-    let mut player = Player::new(Position { x: 2, y: 1 });
+    let mut player = PlayerState::new(Position { x: 2, y: 1 });
 
     assert!(player.handle_motion(VimMotion::H, None, &mut map));
     assert_eq!(player.position, Position { x: 1, y: 1 });
@@ -40,7 +39,7 @@ fn player_step_left() {
 #[test]
 fn player_step_down() {
     let mut map = test_map(5, 5);
-    let mut player = Player::new(Position { x: 1, y: 1 });
+    let mut player = PlayerState::new(Position { x: 1, y: 1 });
 
     assert!(player.handle_motion(VimMotion::J, None, &mut map));
     assert_eq!(player.position, Position { x: 1, y: 2 });
@@ -49,7 +48,7 @@ fn player_step_down() {
 #[test]
 fn player_step_up() {
     let mut map = test_map(5, 5);
-    let mut player = Player::new(Position { x: 1, y: 2 });
+    let mut player = PlayerState::new(Position { x: 1, y: 2 });
 
     assert!(player.handle_motion(VimMotion::K, None, &mut map));
     assert_eq!(player.position, Position { x: 1, y: 1 });
@@ -59,7 +58,7 @@ fn player_step_up() {
 fn player_step_into_wall_fails() {
     let mut map = test_map(5, 5);
     map.set_tile(2, 1, Tile::Wall);
-    let mut player = Player::new(Position { x: 1, y: 1 });
+    let mut player = PlayerState::new(Position { x: 1, y: 1 });
 
     assert!(!player.handle_motion(VimMotion::L, None, &mut map));
     assert_eq!(player.position, Position { x: 1, y: 1 });
@@ -68,7 +67,7 @@ fn player_step_into_wall_fails() {
 #[test]
 fn player_step_at_boundary_fails() {
     let mut map = test_map(5, 5);
-    let mut player = Player::new(Position { x: 0, y: 1 });
+    let mut player = PlayerState::new(Position { x: 0, y: 1 });
 
     assert!(!player.handle_motion(VimMotion::H, None, &mut map));
     assert_eq!(player.position, Position { x: 0, y: 1 });
@@ -77,7 +76,7 @@ fn player_step_at_boundary_fails() {
 #[test]
 fn player_step_records_motion() {
     let mut map = test_map(5, 5);
-    let mut player = Player::new(Position { x: 1, y: 1 });
+    let mut player = PlayerState::new(Position { x: 1, y: 1 });
 
     player.handle_motion(VimMotion::L, None, &mut map);
 
@@ -87,7 +86,7 @@ fn player_step_records_motion() {
 #[test]
 fn player_w_jumps_forward() {
     let mut map = test_map(6, 1);
-    let mut player = Player::new(Position { x: 1, y: 0 });
+    let mut player = PlayerState::new(Position { x: 1, y: 0 });
 
     assert!(player.handle_motion(VimMotion::W, None, &mut map));
     assert_eq!(player.position, Position { x: 5, y: 0 });
@@ -97,7 +96,7 @@ fn player_w_jumps_forward() {
 fn player_w_stops_at_wall() {
     let mut map = test_map(6, 1);
     map.set_tile(2, 0, Tile::Wall);
-    let mut player = Player::new(Position { x: 1, y: 0 });
+    let mut player = PlayerState::new(Position { x: 1, y: 0 });
 
     assert!(!player.handle_motion(VimMotion::W, None, &mut map));
     assert_eq!(player.position, Position { x: 1, y: 0 });
@@ -106,7 +105,7 @@ fn player_w_stops_at_wall() {
 #[test]
 fn player_b_jumps_backward() {
     let mut map = test_map(6, 1);
-    let mut player = Player::new(Position { x: 4, y: 0 });
+    let mut player = PlayerState::new(Position { x: 4, y: 0 });
 
     assert!(player.handle_motion(VimMotion::B, None, &mut map));
     assert_eq!(player.position, Position { x: 0, y: 0 });
@@ -116,7 +115,7 @@ fn player_b_jumps_backward() {
 fn player_b_stops_at_wall() {
     let mut map = test_map(6, 1);
     map.set_tile(3, 0, Tile::Wall);
-    let mut player = Player::new(Position { x: 4, y: 0 });
+    let mut player = PlayerState::new(Position { x: 4, y: 0 });
 
     assert!(!player.handle_motion(VimMotion::B, None, &mut map));
     assert_eq!(player.position, Position { x: 4, y: 0 });
@@ -127,7 +126,7 @@ fn player_zero_jumps_to_row_start() {
     let mut map = test_map(6, 1);
     map.set_tile(0, 0, Tile::Wall);
     map.set_tile(1, 0, Tile::Wall);
-    let mut player = Player::new(Position { x: 4, y: 0 });
+    let mut player = PlayerState::new(Position { x: 4, y: 0 });
 
     assert!(player.handle_motion(VimMotion::Zero, None, &mut map));
     assert_eq!(player.position, Position { x: 2, y: 0 });
@@ -137,7 +136,7 @@ fn player_zero_jumps_to_row_start() {
 fn player_dollar_jumps_to_row_end() {
     let mut map = test_map(6, 1);
     map.set_tile(5, 0, Tile::Wall);
-    let mut player = Player::new(Position { x: 1, y: 0 });
+    let mut player = PlayerState::new(Position { x: 1, y: 0 });
 
     assert!(player.handle_motion(VimMotion::Dollar, None, &mut map));
     assert_eq!(player.position, Position { x: 4, y: 0 });
@@ -147,7 +146,7 @@ fn player_dollar_jumps_to_row_end() {
 fn player_find_char_finds_target() {
     let mut map = test_map(6, 1);
     map.set_tile(4, 0, Tile::Exit);
-    let mut player = Player::new(Position { x: 1, y: 0 });
+    let mut player = PlayerState::new(Position { x: 1, y: 0 });
 
     assert!(player.handle_motion(VimMotion::Find, Some('>'), &mut map));
     assert_eq!(player.position, Position { x: 4, y: 0 });
@@ -156,7 +155,7 @@ fn player_find_char_finds_target() {
 #[test]
 fn player_find_char_not_found_fails() {
     let mut map = test_map(6, 1);
-    let mut player = Player::new(Position { x: 1, y: 0 });
+    let mut player = PlayerState::new(Position { x: 1, y: 0 });
 
     assert!(!player.handle_motion(VimMotion::Find, Some('>'), &mut map));
     assert_eq!(player.position, Position { x: 1, y: 0 });
@@ -166,7 +165,7 @@ fn player_find_char_not_found_fails() {
 fn player_till_char_stops_before_target() {
     let mut map = test_map(6, 1);
     map.set_tile(4, 0, Tile::Exit);
-    let mut player = Player::new(Position { x: 1, y: 0 });
+    let mut player = PlayerState::new(Position { x: 1, y: 0 });
 
     assert!(player.handle_motion(VimMotion::Till, Some('>'), &mut map));
     assert_eq!(player.position, Position { x: 3, y: 0 });
@@ -176,7 +175,7 @@ fn player_till_char_stops_before_target() {
 fn player_dd_destroys_obstacle() {
     let mut map = test_map(6, 1);
     map.set_tile(3, 0, Tile::Obstacle);
-    let mut player = Player::new(Position { x: 1, y: 0 });
+    let mut player = PlayerState::new(Position { x: 1, y: 0 });
 
     assert!(player.handle_motion(VimMotion::DeleteLine, None, &mut map));
     assert_eq!(map.get_tile(3, 0), Tile::Floor);
@@ -185,7 +184,7 @@ fn player_dd_destroys_obstacle() {
 #[test]
 fn player_dd_no_obstacle_fails() {
     let mut map = test_map(6, 1);
-    let mut player = Player::new(Position { x: 1, y: 0 });
+    let mut player = PlayerState::new(Position { x: 1, y: 0 });
 
     assert!(!player.handle_motion(VimMotion::DeleteLine, None, &mut map));
 }
@@ -195,7 +194,7 @@ fn player_g_jumps_to_column_bottom() {
     let mut map = test_map(5, 5);
     map.set_tile(2, 4, Tile::Wall);
     map.set_tile(2, 3, Tile::Wall);
-    let mut player = Player::new(Position { x: 2, y: 0 });
+    let mut player = PlayerState::new(Position { x: 2, y: 0 });
 
     assert!(player.handle_motion(VimMotion::G, None, &mut map));
     assert_eq!(player.position, Position { x: 2, y: 2 });
@@ -206,7 +205,7 @@ fn player_gg_jumps_to_column_top() {
     let mut map = test_map(5, 5);
     map.set_tile(2, 0, Tile::Wall);
     map.set_tile(2, 1, Tile::Wall);
-    let mut player = Player::new(Position { x: 2, y: 4 });
+    let mut player = PlayerState::new(Position { x: 2, y: 4 });
 
     assert!(player.handle_motion(VimMotion::GotoLine, None, &mut map));
     assert_eq!(player.position, Position { x: 2, y: 2 });
@@ -225,7 +224,7 @@ fn player_g_no_passable_rows_fails() {
         enemy_patrol_areas: vec![],
     };
     map.set_tile(2, 2, Tile::Floor);
-    let mut player = Player::new(Position { x: 2, y: 2 });
+    let mut player = PlayerState::new(Position { x: 2, y: 2 });
 
     assert!(!player.handle_motion(VimMotion::G, None, &mut map));
     assert_eq!(player.position, Position { x: 2, y: 2 });
@@ -244,7 +243,7 @@ fn player_gg_no_passable_in_column_fails() {
         enemy_patrol_areas: vec![],
     };
     map.set_tile(2, 2, Tile::Floor);
-    let mut player = Player::new(Position { x: 2, y: 2 });
+    let mut player = PlayerState::new(Position { x: 2, y: 2 });
 
     assert!(!player.handle_motion(VimMotion::GotoLine, None, &mut map));
     assert_eq!(player.position, Position { x: 2, y: 2 });
@@ -254,7 +253,7 @@ fn player_gg_no_passable_in_column_fails() {
 fn player_g_stops_at_wall() {
     let mut map = test_map(5, 5);
     map.set_tile(2, 2, Tile::Wall);
-    let mut player = Player::new(Position { x: 2, y: 1 });
+    let mut player = PlayerState::new(Position { x: 2, y: 1 });
 
     assert!(!player.handle_motion(VimMotion::G, None, &mut map));
     assert_eq!(player.position, Position { x: 2, y: 1 });
@@ -264,7 +263,7 @@ fn player_g_stops_at_wall() {
 fn player_gg_stops_at_wall() {
     let mut map = test_map(5, 5);
     map.set_tile(2, 3, Tile::Wall);
-    let mut player = Player::new(Position { x: 2, y: 4 });
+    let mut player = PlayerState::new(Position { x: 2, y: 4 });
 
     assert!(!player.handle_motion(VimMotion::GotoLine, None, &mut map));
     assert_eq!(player.position, Position { x: 2, y: 4 });
@@ -273,7 +272,7 @@ fn player_gg_stops_at_wall() {
 #[test]
 fn player_g_already_on_target_row_returns_false() {
     let mut map = test_map(5, 5);
-    let mut player = Player::new(Position { x: 0, y: 4 });
+    let mut player = PlayerState::new(Position { x: 0, y: 4 });
 
     assert!(!player.handle_motion(VimMotion::G, None, &mut map));
     assert_eq!(player.position, Position { x: 0, y: 4 });
@@ -282,7 +281,7 @@ fn player_g_already_on_target_row_returns_false() {
 #[test]
 fn player_gg_already_at_column_top_returns_false() {
     let mut map = test_map(5, 5);
-    let mut player = Player::new(Position { x: 0, y: 0 });
+    let mut player = PlayerState::new(Position { x: 0, y: 0 });
 
     assert!(!player.handle_motion(VimMotion::GotoLine, None, &mut map));
     assert_eq!(player.position, Position { x: 0, y: 0 });
@@ -311,7 +310,7 @@ fn player_handle_motion_records_in_used_motions() {
         map.set_tile(2, 0, Tile::Wall);
         map.set_tile(6, 0, Tile::Exit);
         map.set_tile(5, 0, Tile::Obstacle);
-        let mut player = Player::new(Position { x: 4, y: 1 });
+        let mut player = PlayerState::new(Position { x: 4, y: 1 });
         let target = match motion {
             VimMotion::Find | VimMotion::Till => Some('>'),
             _ => None,

--- a/tests/renderer.rs
+++ b/tests/renderer.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 use std::time::Instant;
 use vim_rogue::animation::{AnimationState, AttackEffectKind, ENEMY_MOVE_MS};
 use vim_rogue::map::Map;
-use vim_rogue::player::Player;
 use vim_rogue::renderer::*;
 use vim_rogue::types::{App, Enemy, GameState, MAX_HP, Position, Tile, VimMotion, Zone};
 use vim_rogue::visibility::{VisibilityMap, VisibilityState};
@@ -335,7 +334,7 @@ fn minimap_hidden_tile_is_blank() {
 #[test]
 fn minimap_player_position_at_start() {
     let app = test_app();
-    let (px, py) = minimap_player_pos(app.player.inner.position.x, app.player.inner.position.y);
+    let (px, py) = minimap_player_pos(app.player.position.x, app.player.position.y);
     assert!(px >= 0 && px < MINIMAP_WIDTH as i32, "player minimap x should be in range, got {px}");
     assert!(py >= 0 && py < MINIMAP_HEIGHT as i32, "player minimap y should be in range, got {py}");
 }


### PR DESCRIPTION
## Summary
- Merge `Player` struct into `PlayerState`, eliminating the `inner: Player` indirection layer
- `handle_motion` now owns motion tracking (`motion_count`, `discovered_motions`) instead of game.rs
- All 80+ `.inner.` accesses replaced with direct field access across src/ and tests/

## Test plan
- [x] All 393 tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` zero warnings
- [x] `Player` struct no longer exists
- [x] Zero `.inner.` accesses in codebase

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Inline the Player struct into PlayerState and update game logic, rendering, and tests to use PlayerState as the single source of player data.

Enhancements:
- Remove the Player wrapper struct and move its fields and motion handling logic directly into PlayerState.
- Have PlayerState::handle_motion track motion count and discovered motions internally instead of external bookkeeping in the game loop.
- Update game logic, rendering helpers, and tests to access player fields directly on PlayerState rather than through an inner field.