### PR TITLE
refactor: move enemy turn into World — deepen aggregate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- Generated: 2026-04-17 | Updated: 2026-04-29 -->
-<!-- Commit: HEAD | Branch: refactor/merge-player-into-playerstate -->
+<!-- Generated: 2026-04-17 | Updated: 2026-05-01 -->
+<!-- Commit: HEAD | Branch: refactor/enemy-turn-into-world -->
 
 # vim-rogue
 
@@ -21,11 +21,11 @@ vim-rogue/
 ## Architecture
 ```
 main.rs       → bracket-lib setup + event loop (44 lines)
-game.rs       → App coordinator — sequences cross-aggregate flows: level transitions, collision→damage, pause/resume (740 lines)
+game.rs       → App coordinator — thin enemies_step coordinator (collision outcomes, animation, audio), sequences cross-aggregate flows: level transitions, pause/resume (647 lines)
 player.rs     → PlayerState impl — 13 motions + motion tracking (260 lines)
 map.rs        → 80×40 grid, 5 zones, 4 dungeon levels, corridor carving, enemy spawns + patrol areas (471 lines)
 renderer.rs   → bracket-lib rendering: title, viewport, sidebar, minimap, win/loss screens, ASCII art (914 lines)
-types.rs      → Position, Tile, Zone, VimMotion, Direction, Enemy, PatrolArea, PlayerState (position, motions, noclip), App + 3 aggregates (World, InputState, Session), RenderGrid, ViewModel (560 lines)
+types.rs      → Position, Tile, Zone, VimMotion, Direction, Enemy, PatrolArea, EnemyMovement, EnemyTurn, PlayerState, App + 3 aggregates (World owns step_enemies + push_enemies_off_position, InputState, Session), RenderGrid, ViewModel (691 lines)
 animation.rs  → GameClock, AnimationState, AnimationTimer, Interpolator (easing) (182 lines)
 visibility.rs → VisibilityMap with FOV (explored/visible/hidden states) (124 lines)
 enemy.rs      → Enemy struct with FOV-aware BFS chase + room patrol (180 lines)
@@ -42,7 +42,7 @@ lib.rs        → Re-exports all modules (9 lines)
 | Change game flow | `src/game.rs` (handle_key, tick, execute_motion) | Two-phase input for f/t/dd/gg; ESC/q = pause |
 | Change pause menu | `src/game.rs` + `src/renderer.rs` + `src/types.rs` | GameState::Paused, PauseOption, render_pause_overlay |
 | Add new types | `src/types.rs` | All modules use `crate::types::*` |
-| Change enemy AI | `src/enemy.rs` (step_toward_player, has_line_of_sight, patrol_step) | FOV-gated BFS chase + patrol, called from World.enemies_step |
+| Change enemy AI | `src/enemy.rs` + `src/types.rs` (World::step_enemies) | FOV-gated BFS chase + patrol in enemy.rs; turn orchestration in World |
 | Change FOV/visibility | `src/visibility.rs` (compute_fov) | Hidden/Explored/Visible states |
 | Change aggregate logic | `src/types.rs` (World, InputState, Session) + `src/player.rs` (PlayerState) | PlayerState flat struct; each aggregate owns its domain; App coordinates |
 | Add animations | `src/animation.rs` | AnimationState + Interpolator; GameClock trait |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Move enemy turn into World aggregate** — `enemies_step` AI dispatch (LOS check, chase, patrol, stun decrement) moved from game.rs into `World::step_enemies`, returning structured `EnemyTurn` result; `push_enemies_off_position` (BFS respawn displacement) moved into `World::push_enemies_off_position`; game.rs `enemies_step` reduced to thin coordinator handling collision outcomes, animation, and audio from returned data
+
+### Added
+
+- `EnemyMovement` and `EnemyTurn` structs — structured result types for `World::step_enemies`
+
 ## [0.3.0] - 2026-04-29
 
 ### Changed

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-04-17 | Updated: 2026-04-29 (PR#11) -->
+<!-- Generated: 2026-04-17 | Updated: 2026-05-01 (PR#12) -->
 # src
 
 All vim-rogue source. Tests in `tests/` (integration only).
@@ -9,11 +9,11 @@ All vim-rogue source. Tests in `tests/` (integration only).
 |------|-------|------|
 | `main.rs` | 44 | Binary entry — bracket-lib setup, event loop, `ctx.quit()`, delegates to game/renderer |
 | `lib.rs` | 9 | Library root — `pub mod` re-exports |
-| `game.rs` | 740 | App coordinator — `handle_key`/`tick`, sequences cross-aggregate flows (level transitions, collision→damage, pause/resume) |
+| `game.rs` | 647 | App coordinator — `handle_key`/`tick`, thin `enemies_step` coordinator (collision outcomes, animation, audio) |
 | `player.rs` | 260 | `PlayerState` impl — 13 motions + motion tracking (h/j/k/l/w/b/0/$/G/gg/f/t/dd) |
 | `map.rs` | 471 | `Map`, 80×40 grid, 5 zones, 4 levels (`carve_level`, `build_level_2/3/4`), enemy spawns + patrol areas |
 | `renderer.rs` | 914 | bracket-lib render — title/gameplay/win/lost/pause screens, viewport, sidebar, minimap, zone colors |
-| `types.rs` | 560 | Position, Tile, Zone, VimMotion, Direction, Enemy, PatrolArea, PlayerState (position, motions, noclip), App + 3 aggregates (World, InputState, Session), RenderGrid, ViewModel, ScreenModel |
+| `types.rs` | 691 | Position, Tile, Zone, VimMotion, Direction, Enemy, PatrolArea, EnemyMovement, EnemyTurn, PlayerState, App + 3 aggregates (World, InputState, Session), RenderGrid, ViewModel, ScreenModel |
 | `animation.rs` | 182 | `GameClock` trait, `RealClock`/`TestClock`, `AnimationState`, `AnimationTimer`, `Interpolator` |
 | `visibility.rs` | 124 | `VisibilityMap` + `compute_fov`, `VisibilityState` (Hidden/Explored/Visible) |
 | `enemy.rs` | 180 | `Enemy` + FOV-aware BFS `step_toward_player`, `has_line_of_sight`, `patrol_step` |
@@ -28,7 +28,7 @@ All vim-rogue source. Tests in `tests/` (integration only).
 | Change game flow | `game.rs` | handle_key, tick, pending_input for f/t/dd/gg; ESC/q opens pause |
 | Change pause menu | `game.rs` + `renderer.rs` + `types.rs` | GameState::Paused, PauseOption, render_pause_overlay |
 | Add shared type | `types.rs` | All modules `use crate::types::*` |
-| Change enemy AI | `enemy.rs` | step_toward_player (BFS), has_line_of_sight (Bresenham), patrol_step, called via World.enemies_step |
+| Change enemy AI | `enemy.rs` + `types.rs` | step_toward_player (BFS), has_line_of_sight (Bresenham), patrol_step in enemy.rs; `World::step_enemies` orchestrates turn in types.rs |
 | Change visibility | `visibility.rs` | compute_fov, VisibilityMap, demote_visible_to_explored |
 | Change aggregate logic | `types.rs` + `player.rs` | World (terrain, visibility, enemies), PlayerState (position, motions, HP, trail, progression; impl in player.rs), InputState (key buffering), Session (lifecycle, timing, pause) |
 | Add animation | `animation.rs` | AnimationState + Interpolator; durations as constants |
@@ -52,7 +52,7 @@ lib.rs        ← main.rs (implicit)
 - `rustfmt.toml`: `use_small_heuristics = "Max"`, `edition = "2024"`. Run `cargo fmt --check` pre-commit.
 - `grid[y][x]` row-major — always bounds-check.
 - **Aggregates**: `App` is a thin coordinator delegating to 3 domain aggregates + PlayerState:
-  - `World` — terrain, visibility, enemies, torchlights; owns `update_visibility`, `enemies_step`, `reset_for_level`
+  - `World` — terrain, visibility, enemies, torchlights; owns `update_visibility`, `step_enemies`, `push_enemies_off_position`, `reset_for_level`
   - `PlayerState` — flat struct (position, used_motions, last_direction, noclip, HP, trail, motion tracking, level, checkpoint, pending respawn); `impl PlayerState` in player.rs owns all motion logic + tracking (motion_count, discovered_motions)
   - `InputState` — `input_queue` + `pending_input` for two-phase Vim commands (f/t/dd/gg)
   - `Session` — game state, pause selection, timing, status message

--- a/src/game.rs
+++ b/src/game.rs
@@ -113,7 +113,7 @@ pub fn tick(app: &mut App, delta_ms: f64) {
                     app.player.position = pos;
                     app.player_animation = None;
                     app.session.game_state = GameState::Playing;
-                    push_enemies_off_position(app, pos);
+                    app.world.push_enemies_off_position(pos);
                     app.update_visibility();
                     app.session.status_message = String::from("Respawned at checkpoint!");
                 }
@@ -435,132 +435,45 @@ fn parse_motion(key: VirtualKeyCode, shift: bool) -> Option<ParsedInput> {
     }
 }
 
-fn push_enemies_off_position(app: &mut App, pos: crate::types::Position) {
-    use std::collections::{HashSet, VecDeque};
-    let directions: [(isize, isize); 4] = [(-1, 0), (1, 0), (0, -1), (0, 1)];
-    let mut new_positions: Vec<Option<crate::types::Position>> =
-        vec![None; app.world.enemies.len()];
-    let mut claimed: HashSet<crate::types::Position> = HashSet::new();
-
-    let enemies_on_pos: Vec<usize> = app
-        .world
-        .enemies
-        .iter()
-        .enumerate()
-        .filter(|(_, e)| e.position == pos)
-        .map(|(i, _)| i)
-        .collect();
-
-    if enemies_on_pos.is_empty() {
-        return;
-    }
-
-    let mut visited: HashSet<crate::types::Position> = HashSet::new();
-    visited.insert(pos);
-    let mut bfs: VecDeque<crate::types::Position> = VecDeque::new();
-    for (dx, dy) in &directions {
-        let nx = (pos.x as isize + dx) as usize;
-        let ny = (pos.y as isize + dy) as usize;
-        if nx < app.world.map.width
-            && ny < app.world.map.height
-            && app.world.map.is_passable(nx, ny)
-        {
-            let neighbor = crate::types::Position { x: nx, y: ny };
-            if visited.insert(neighbor) {
-                bfs.push_back(neighbor);
-            }
-        }
-    }
-
-    let mut assigned = 0;
-    while assigned < enemies_on_pos.len() {
-        let candidate = match bfs.pop_front() {
-            Some(c) => c,
-            None => break,
-        };
-
-        if candidate.x < app.world.map.width
-            && candidate.y < app.world.map.height
-            && app.world.map.is_passable(candidate.x, candidate.y)
-            && !claimed.contains(&candidate)
-            && !app.world.enemies.iter().any(|e| e.position == candidate)
-        {
-            let idx = enemies_on_pos[assigned];
-            new_positions[idx] = Some(candidate);
-            claimed.insert(candidate);
-            assigned += 1;
-        }
-
-        for (dx, dy) in &directions {
-            let nx = (candidate.x as isize + dx) as usize;
-            let ny = (candidate.y as isize + dy) as usize;
-            if nx < app.world.map.width
-                && ny < app.world.map.height
-                && app.world.map.is_passable(nx, ny)
-            {
-                let neighbor = crate::types::Position { x: nx, y: ny };
-                if visited.insert(neighbor) {
-                    bfs.push_back(neighbor);
-                }
-            }
-        }
-    }
-
-    for (i, enemy) in app.world.enemies.iter_mut().enumerate() {
-        if let Some(new_pos) = new_positions[i] {
-            enemy.position = new_pos;
-        }
-    }
-}
-
 fn enemies_step(app: &mut App) {
     let player_pos = app.player.position;
+    let turn = app.world.step_enemies(player_pos);
+
     let mut prior_animations = vec![None; app.world.enemies.len()];
     for (enemy_index, animation) in std::mem::take(&mut app.enemy_animations) {
         if enemy_index < prior_animations.len() {
             prior_animations[enemy_index] = Some(animation);
         }
     }
-    let old_positions: Vec<crate::types::Position> =
-        app.world.enemies.iter().map(|enemy| enemy.position).collect();
-    let old_visual_positions: Vec<(f64, f64)> = app
-        .world
-        .enemies
+
+    let old_visual_positions: Vec<(f64, f64)> = turn
+        .prior_positions
         .iter()
         .enumerate()
-        .map(|(index, enemy)| {
+        .map(|(index, old_pos)| {
             prior_animations[index]
                 .map(|animation| animation.current_position())
-                .unwrap_or((enemy.position.x as f64, enemy.position.y as f64))
+                .unwrap_or((old_pos.x as f64, old_pos.y as f64))
         })
         .collect();
 
-    for enemy in &mut app.world.enemies {
-        if enemy.stunned_turns > 0 {
-            enemy.stunned_turns -= 1;
-        } else {
-            let moved = if enemy.has_line_of_sight(player_pos, &app.world.map) {
-                enemy.step_toward_player(player_pos, &app.world.map)
-            } else {
-                enemy.patrol_step(&app.world.map)
-            };
-            if moved {
-                app.audio.play(SoundEffect::EnemyStep);
-            }
-        }
+    if !turn.movements.is_empty() {
+        app.audio.play(SoundEffect::EnemyStep);
     }
 
     let player_pos = app.player.position;
     let invincible = app.is_invincible();
     let mut remaining_enemies = Vec::with_capacity(app.world.enemies.len());
     let mut next_animations = Vec::new();
-    for (old_index, ((old_position, old_visual_position), enemy)) in old_positions
+    for (old_index, ((old_position, old_visual_position), enemy)) in turn
+        .prior_positions
         .into_iter()
         .zip(old_visual_positions)
         .zip(app.world.enemies.drain(..))
         .enumerate()
     {
-        if enemy.position == player_pos
+        let collided = turn.collisions.contains(&old_index);
+        if collided
             && enemy.stunned_turns == 0
             && app.session.game_state == GameState::Playing
             && !invincible

--- a/src/game.rs
+++ b/src/game.rs
@@ -457,7 +457,7 @@ fn enemies_step(app: &mut App) {
         })
         .collect();
 
-    if !turn.movements.is_empty() {
+    for _ in &turn.movements {
         app.audio.play(SoundEffect::EnemyStep);
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -323,6 +323,20 @@ pub struct Enemy {
     pub patrol_area: PatrolArea,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnemyMovement {
+    pub old_index: usize,
+    pub old_pos: Position,
+    pub new_pos: Position,
+}
+
+#[derive(Debug, Clone)]
+pub struct EnemyTurn {
+    pub movements: Vec<EnemyMovement>,
+    pub collisions: Vec<usize>,
+    pub prior_positions: Vec<Position>,
+}
+
 #[cfg(debug_assertions)]
 #[derive(Debug, Clone)]
 pub struct CheatBuffer {
@@ -409,6 +423,110 @@ impl World {
                 }
             })
             .collect();
+    }
+
+    pub fn step_enemies(&mut self, player_pos: Position) -> EnemyTurn {
+        let prior_positions: Vec<Position> = self.enemies.iter().map(|e| e.position).collect();
+        let mut movements = Vec::new();
+
+        for enemy in &mut self.enemies {
+            if enemy.stunned_turns > 0 {
+                enemy.stunned_turns -= 1;
+            } else if enemy.has_line_of_sight(player_pos, &self.map) {
+                enemy.step_toward_player(player_pos, &self.map);
+            } else {
+                enemy.patrol_step(&self.map);
+            }
+        }
+
+        for (i, (old_pos, enemy)) in prior_positions.iter().zip(self.enemies.iter()).enumerate() {
+            if enemy.position != *old_pos {
+                movements.push(EnemyMovement {
+                    old_index: i,
+                    old_pos: *old_pos,
+                    new_pos: enemy.position,
+                });
+            }
+        }
+
+        let collisions: Vec<usize> = self
+            .enemies
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| e.position == player_pos)
+            .map(|(i, _)| i)
+            .collect();
+
+        EnemyTurn { movements, collisions, prior_positions }
+    }
+
+    pub fn push_enemies_off_position(&mut self, pos: Position) {
+        let directions: [(isize, isize); 4] = [(-1, 0), (1, 0), (0, -1), (0, 1)];
+        let mut new_positions: Vec<Option<Position>> = vec![None; self.enemies.len()];
+        let mut claimed: HashSet<Position> = HashSet::new();
+
+        let enemies_on_pos: Vec<usize> = self
+            .enemies
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| e.position == pos)
+            .map(|(i, _)| i)
+            .collect();
+
+        if enemies_on_pos.is_empty() {
+            return;
+        }
+
+        let mut visited: HashSet<Position> = HashSet::new();
+        visited.insert(pos);
+        let mut bfs: std::collections::VecDeque<Position> = std::collections::VecDeque::new();
+        for (dx, dy) in &directions {
+            let nx = (pos.x as isize + dx) as usize;
+            let ny = (pos.y as isize + dy) as usize;
+            if nx < self.map.width && ny < self.map.height && self.map.is_passable(nx, ny) {
+                let neighbor = Position { x: nx, y: ny };
+                if visited.insert(neighbor) {
+                    bfs.push_back(neighbor);
+                }
+            }
+        }
+
+        let mut assigned = 0;
+        while assigned < enemies_on_pos.len() {
+            let candidate = match bfs.pop_front() {
+                Some(c) => c,
+                None => break,
+            };
+
+            if candidate.x < self.map.width
+                && candidate.y < self.map.height
+                && self.map.is_passable(candidate.x, candidate.y)
+                && !claimed.contains(&candidate)
+                && !self.enemies.iter().any(|e| e.position == candidate)
+            {
+                let idx = enemies_on_pos[assigned];
+                new_positions[idx] = Some(candidate);
+                claimed.insert(candidate);
+                assigned += 1;
+            }
+
+            for (dx, dy) in &directions {
+                let nx = (candidate.x as isize + dx) as usize;
+                let ny = (candidate.y as isize + dy) as usize;
+                if nx < self.map.width && ny < self.map.height && self.map.is_passable(nx, ny) {
+                    let neighbor = Position { x: nx, y: ny };
+                    if visited.insert(neighbor) {
+                        bfs.push_back(neighbor);
+                    }
+                }
+            }
+        }
+
+        for (i, enemy) in self.enemies.iter_mut().enumerate() {
+            if let Some(new_pos) = new_positions[i] {
+                enemy.position = new_pos;
+            }
+        }
     }
 
     pub fn update_visibility(&mut self, player_pos: Position) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -333,7 +333,7 @@ pub struct EnemyMovement {
 #[derive(Debug, Clone)]
 pub struct EnemyTurn {
     pub movements: Vec<EnemyMovement>,
-    pub collisions: Vec<usize>,
+    pub collisions: HashSet<usize>,
     pub prior_positions: Vec<Position>,
 }
 
@@ -449,7 +449,7 @@ impl World {
             }
         }
 
-        let collisions: Vec<usize> = self
+        let collisions: HashSet<usize> = self
             .enemies
             .iter()
             .enumerate()


### PR DESCRIPTION
## Summary

- Move `enemies_step` AI dispatch (LOS check, chase, patrol, stun decrement) from game.rs into `World::step_enemies`, returning structured `EnemyTurn` result
- Move `push_enemies_off_position` (BFS respawn displacement) into `World::push_enemies_off_position`
- Reduce game.rs `enemies_step` to thin coordinator — handles collision outcomes, animation, audio from returned data
- Add `EnemyMovement` and `EnemyTurn` result types to types.rs

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy` zero warnings
- [x] All 396 integration tests pass (no behavior changes)
- [x] Docs updated (CLAUDE.md, src/AGENTS.md, CHANGELOG.md)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Move enemy turn logic into the World aggregate and expose a structured result for the game coordinator.

New Features:
- Add EnemyMovement and EnemyTurn structs to represent per-turn enemy movements and collisions returned from World::step_enemies.

Enhancements:
- Introduce World::step_enemies and World::push_enemies_off_position to encapsulate enemy AI turns and respawn displacement inside the World aggregate.
- Simplify game.rs enemies_step to consume EnemyTurn results for collisions, animations, and audio rather than driving AI directly.

Documentation:
- Update architecture and agent documentation to reflect World-owned enemy turn orchestration and new result types.

Tests:
- Document that the existing integration test suite continues to pass with no behavioral changes.